### PR TITLE
로그인페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
     "i": "^0.3.7",
     "npm": "^11.5.2",
     "react": "^19.1.1",
@@ -17,7 +18,8 @@
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.8.1",
     "react-toastify": "^11.0.5",
-    "styled-components": "^6.1.19"
+    "styled-components": "^6.1.19",
+    "zod": "^4.1.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "npm": "^11.5.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.8.1",
     "react-toastify": "^11.0.5",
     "styled-components": "^6.1.19"

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+import type { FieldError, UseFormRegister, Path } from 'react-hook-form';
+import { fontSystem } from '@/styles/fontSystem';
+import { colorSystem } from '@/styles/colorSystem';
+
+interface InputFieldProps<TFormValues extends Record<string, unknown>> {
+  id: Path<TFormValues>;
+  label: string;
+  type?: 'text' | 'email' | 'password';
+  placeholder?: string;
+  register: UseFormRegister<TFormValues>;
+  error?: FieldError;
+}
+
+export function InputField<TFormValues extends Record<string, unknown>>({
+  id,
+  label,
+  type = 'text',
+  placeholder,
+  register,
+  error,
+}: InputFieldProps<TFormValues>) {
+  return (
+    <InputGroup>
+      <StyledLabel htmlFor={id}>{label}</StyledLabel>
+      <StyledInput
+        id={id}
+        type={type}
+        placeholder={placeholder}
+        {...register(id)}
+        aria-invalid={error ? 'true' : 'false'}
+      />
+      {error && <ErrorMsg role="alert">{error.message}</ErrorMsg>}
+    </InputGroup>
+  );
+}
+
+const InputGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+`;
+
+const StyledLabel = styled.label`
+  ${fontSystem.body.medium}
+  color: ${colorSystem.tertiary_white._300};
+`;
+
+const StyledInput = styled.input`
+  padding: 12px 14px;
+  border: 1px solid ${colorSystem.tertiary_white._100};
+  border-radius: 6px;
+  ${fontSystem.body.medium}
+  transition: border-color 0.2s;
+
+  &:focus {
+    outline: none;
+    border-color: ${colorSystem.tertiary_white._600};
+  }
+`;
+
+const ErrorMsg = styled.span`
+  margin-left: 4px;
+  color: red;
+  ${fontSystem.body.small}
+`;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -3,6 +3,8 @@ import logo from '../../../public/logo.svg';
 import { fontSystem } from '@/styles/fontSystem';
 import { colorSystem } from '@/styles/colorSystem';
 import { useLoginForm } from './hooks/useLoginForm';
+import { InputField } from '@/components/InputField';
+import type { LoginFormInputs } from './utils/loginValidation';
 
 function LoginPage() {
   const { register, handleSubmit, errors, isValid, navigateToRegister } = useLoginForm();
@@ -12,26 +14,22 @@ function LoginPage() {
       <Logo src={logo} alt="logo" />
       <Title>로그인</Title>
       <StyledForm onSubmit={handleSubmit} noValidate>
-        <InputGroup>
-          <StyledLabel htmlFor="email">이메일</StyledLabel>
-          <StyledInput
-            id="email"
-            type="email"
-            placeholder="이메일을 입력해주세요"
-            {...register('email', { required: '이메일을 입력해주세요' })}
-          />
-          {errors.email && <ErrorMsg>{errors.email.message}</ErrorMsg>}
-        </InputGroup>
-        <InputGroup>
-          <StyledLabel htmlFor="password">비밀번호</StyledLabel>
-          <StyledInput
-            id="password"
-            type="password"
-            placeholder="비밀번호를 입력해주세요"
-            {...register('password', { required: '비밀번호를 입력해주세요' })}
-          />
-          {errors.password && <ErrorMsg>{errors.password.message}</ErrorMsg>}
-        </InputGroup>
+        <InputField<LoginFormInputs>
+          id="email"
+          label="이메일"
+          type="email"
+          placeholder="이메일을 입력해주세요"
+          register={register}
+          error={errors.email}
+        />
+        <InputField<LoginFormInputs>
+          id="password"
+          label="비밀번호"
+          type="password"
+          placeholder="비밀번호를 입력해주세요"
+          register={register}
+          error={errors.password}
+        />
         <SignupGuide>
           아직 계정이 없으신가요?{' '}
           <SignupLink type="button" onClick={navigateToRegister}>
@@ -68,6 +66,7 @@ const Title = styled.h2`
 const StyledForm = styled.form`
   display: flex;
   flex-direction: column;
+  align-items: center; // InputField가 width: 100%를 가지므로 정렬을 위해 추가
   gap: 16px;
   width: 320px;
   background: #fff;
@@ -76,38 +75,10 @@ const StyledForm = styled.form`
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
 `;
 
-const InputGroup = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-`;
-
-const StyledLabel = styled.label`
-  ${fontSystem.body.medium}
-  color: ${colorSystem.tertiary_white._300}
-`;
-
-const StyledInput = styled.input`
-  padding: 12px 14px;
-  border: 1px solid ${colorSystem.tertiary_white._100};
-  border-radius: 6px;
-  ${fontSystem.body.medium}
-  transition: border-color 0.2s;
-  &:focus {
-    outline: none;
-    border-color: #222;
-  }
-`;
-
-const ErrorMsg = styled.span`
-  margin-left: 4px;
-  color: red;
-  ${fontSystem.body.small}
-`;
-
 const LoginButton = styled.button`
   margin-top: 12px;
   padding: 12px 0;
+  width: 100%; // 다른 필드와 너비를 맞추기 위해 추가
   background: ${colorSystem.secondary_green._400};
   color: #fff;
   border: none;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -5,7 +5,7 @@ import { colorSystem } from '@/styles/colorSystem';
 import { useLoginForm } from './hooks/useLoginForm';
 
 function LoginPage() {
-  const { register, handleSubmit, errors, navigateToRegister } = useLoginForm();
+  const { register, handleSubmit, errors, isValid, navigateToRegister } = useLoginForm();
 
   return (
     <Container>
@@ -38,7 +38,9 @@ function LoginPage() {
             회원가입
           </SignupLink>
         </SignupGuide>
-        <LoginButton type="submit">로그인</LoginButton>
+        <LoginButton type="submit" disabled={!isValid}>
+          로그인
+        </LoginButton>
       </StyledForm>
     </Container>
   );
@@ -115,6 +117,11 @@ const LoginButton = styled.button`
   transition: background 0.2s;
   &:hover {
     background: ${colorSystem.secondary_green._500};
+  }
+  &:disabled {
+    background: ${colorSystem.tertiary_white._100};
+    color: ${colorSystem.tertiary_white._300};
+    cursor: not-allowed;
   }
 `;
 

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,5 +1,143 @@
+import styled from 'styled-components';
+import logo from '../../../public/logo.svg';
+import { fontSystem } from '@/styles/fontSystem';
+import { colorSystem } from '@/styles/colorSystem';
+import { useLoginForm } from './hooks/useLoginForm';
+
 function LoginPage() {
-  return <>LoginPage test</>;
+  const { register, handleSubmit, errors, navigateToRegister } = useLoginForm();
+
+  return (
+    <Container>
+      <Logo src={logo} alt="logo" />
+      <Title>로그인</Title>
+      <StyledForm onSubmit={handleSubmit} noValidate>
+        <InputGroup>
+          <StyledLabel htmlFor="email">이메일</StyledLabel>
+          <StyledInput
+            id="email"
+            type="email"
+            placeholder="이메일을 입력해주세요"
+            {...register('email', { required: '이메일을 입력해주세요' })}
+          />
+          {errors.email && <ErrorMsg>{errors.email.message}</ErrorMsg>}
+        </InputGroup>
+        <InputGroup>
+          <StyledLabel htmlFor="password">비밀번호</StyledLabel>
+          <StyledInput
+            id="password"
+            type="password"
+            placeholder="비밀번호를 입력해주세요"
+            {...register('password', { required: '비밀번호를 입력해주세요' })}
+          />
+          {errors.password && <ErrorMsg>{errors.password.message}</ErrorMsg>}
+        </InputGroup>
+        <SignupGuide>
+          아직 계정이 없으신가요?{' '}
+          <SignupLink type="button" onClick={navigateToRegister}>
+            회원가입
+          </SignupLink>
+        </SignupGuide>
+        <LoginButton type="submit">로그인</LoginButton>
+      </StyledForm>
+    </Container>
+  );
 }
+
+const Container = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: white;
+`;
+
+const Logo = styled.img`
+  width: 80px;
+  margin-bottom: 24px;
+`;
+
+const Title = styled.h2`
+  margin-bottom: 32px;
+  ${fontSystem.title.xlarge}
+`;
+
+const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 320px;
+  background: #fff;
+  padding: 32px;
+  border-radius: 20px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+`;
+
+const InputGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const StyledLabel = styled.label`
+  ${fontSystem.body.medium}
+  color: ${colorSystem.tertiary_white._300}
+`;
+
+const StyledInput = styled.input`
+  padding: 12px 14px;
+  border: 1px solid ${colorSystem.tertiary_white._100};
+  border-radius: 6px;
+  ${fontSystem.body.medium}
+  transition: border-color 0.2s;
+  &:focus {
+    outline: none;
+    border-color: #222;
+  }
+`;
+
+const ErrorMsg = styled.span`
+  margin-left: 4px;
+  color: red;
+  ${fontSystem.body.small}
+`;
+
+const LoginButton = styled.button`
+  margin-top: 12px;
+  padding: 12px 0;
+  background: ${colorSystem.secondary_green._400};
+  color: #fff;
+  border: none;
+  border-radius: 30px;
+  ${fontSystem.body.large}
+  cursor: pointer;
+  transition: background 0.2s;
+  &:hover {
+    background: ${colorSystem.secondary_green._500};
+  }
+`;
+
+const SignupGuide = styled.div`
+  margin: 10px 0 0 0;
+  text-align: center;
+  ${fontSystem.body.small}
+  color: ${colorSystem.tertiary_white._300};
+`;
+
+const SignupLink = styled.button`
+  background: none;
+  border: none;
+  color: ${colorSystem.secondary_green._400};
+  cursor: pointer;
+  text-decoration: underline;
+  font-weight: 600;
+  font-size: inherit;
+  padding: 0;
+  margin-left: 4px;
+  &:hover {
+    color: ${colorSystem.secondary_green._500};
+  }
+`;
 
 export default LoginPage;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,5 +1,5 @@
 function LoginPage() {
-  return <>LoginPage</>;
+  return <>LoginPage test</>;
 }
 
 export default LoginPage;

--- a/src/pages/login/hooks/useLoginForm.ts
+++ b/src/pages/login/hooks/useLoginForm.ts
@@ -1,0 +1,33 @@
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+type LoginFormInputs = {
+  email: string;
+  password: string;
+};
+
+export const useLoginForm = () => {
+  const navigate = useNavigate();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormInputs>();
+
+  const onSubmit = (data: LoginFormInputs) => {
+    // 로그인 처리 로직 (POST)
+    console.log(data);
+    navigate('/'); // 로그인 후 홈으로 이동
+  };
+
+  const navigateToRegister = () => {
+    navigate('/register');
+  };
+
+  return {
+    register,
+    handleSubmit: handleSubmit(onSubmit),
+    errors,
+    navigateToRegister,
+  };
+};

--- a/src/pages/login/hooks/useLoginForm.ts
+++ b/src/pages/login/hooks/useLoginForm.ts
@@ -1,23 +1,23 @@
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-
-type LoginFormInputs = {
-  email: string;
-  password: string;
-};
+import { zodResolver } from '@hookform/resolvers/zod';
+import { loginSchema, type LoginFormInputs } from '../utils/loginValidation';
 
 export const useLoginForm = () => {
   const navigate = useNavigate();
   const {
     register,
     handleSubmit,
-    formState: { errors },
-  } = useForm<LoginFormInputs>();
+    formState: { errors, isValid },
+  } = useForm<LoginFormInputs>({
+    resolver: zodResolver(loginSchema),
+    mode: 'onChange',
+  });
 
   const onSubmit = (data: LoginFormInputs) => {
-    // 로그인 처리 로직 (POST)
     console.log(data);
-    navigate('/'); // 로그인 후 홈으로 이동
+    // todo : 로그인 API 호출
+    navigate('/');
   };
 
   const navigateToRegister = () => {
@@ -28,6 +28,7 @@ export const useLoginForm = () => {
     register,
     handleSubmit: handleSubmit(onSubmit),
     errors,
+    isValid,
     navigateToRegister,
   };
 };

--- a/src/pages/login/utils/loginValidation.ts
+++ b/src/pages/login/utils/loginValidation.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+//유효성 검사 로직은 백엔드와 상의 후 변경해야할 수 있음.
+export const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, { message: '이메일을 입력해주세요' }) // 비어있지 않아야 함
+    .email({ message: '유효한 이메일 형식이 아닙니다' }), // 이메일 형식이어야 함
+  password: z.string().min(8, { message: '비밀번호는 8자 이상이어야 합니다' }), // 최소 8자 이상
+});
+
+export type LoginFormInputs = z.infer<typeof loginSchema>;


### PR DESCRIPTION
# 로그인페이지 구현

## 설명

- 로그인 기능 추가

- 로그인폼은 react-hook-form 라이브러리 사용했습니다
- 유효성 검사 로직은 zod 라이브러리 이용했습니다
- 아직 API 호출 부분은 구현되지 않았습니다
- 인풋필드는 다른 페이지에서도 많이 사용할 것 같아 공통컴포넌트 InputField.tsx로 정의했습니다
- LoginPage.tsx에서는 UI 로직만 다루고, useLoginForm.ts에서 로그인 폼과 비즈니스로직을 담당합니다
- loginValidation.ts에서 로그인 폼 유효성 검사 스키마를 정의했습니다. 이후 수정 필요할 수 있습니다

- **기타 정보**:

## 관련 이슈
#9 이후에 API 호출 부분 추가해야합니다


<!--- 바로 아래에 이슈 링크를 추가해 주세요.-->
#9 