### PR TITLE
개인 스페이스 페이지 - 회원 정보 수정 기능

### DIFF
--- a/src/pages/space/components/profile/InfoEditWindow.tsx
+++ b/src/pages/space/components/profile/InfoEditWindow.tsx
@@ -11,44 +11,75 @@ import {
   WindowTopBar,
 } from '@/pages/space/styles/modalWindowStyle';
 import { styled } from 'styled-components';
+import { FormInputField } from '@/components/FormInputField';
+import { FormSelectField } from '@/components/FormSelectField';
+import { useEditForm } from '../../hooks/useEditForm';
+import { mbtiTypes, type EditFormInputs } from '../../utils/editValidation';
 
 function InfoEditWindow({ closeModal, member }: ModalPropType & { member: MemberType }) {
+  const { register, handleSubmit, errors, isValid } = useEditForm({
+    defaultValues: { ...member, phone: member.contact },
+    onSubmit: (data: EditFormInputs) => {
+      // todo: PATCH API 호출
+      console.log('서버로 전송할 데이터:', data);
+
+      alert('회원정보 수정이 완료되었습니다!');
+      closeModal();
+    },
+  });
+
   return (
-    <ModalWindowWrapper>
-      <WindowTopBar>
-        <WindowTitle>나의 정보 수정</WindowTitle>
-        <CloseButton onClick={closeModal}>
-          <Close />
-        </CloseButton>
-      </WindowTopBar>
+    <form onSubmit={handleSubmit} noValidate>
+      <ModalWindowWrapper>
+        <WindowTopBar>
+          <WindowTitle>나의 정보 수정</WindowTitle>
+          <CloseButton onClick={closeModal}>
+            <Close />
+          </CloseButton>
+        </WindowTopBar>
 
-      {/* 병합 후 수정 필요 */}
-      <FieldWrapper>
-        <div>
-          <span>이메일</span> <input type="text" value={member.email} disabled />
-        </div>
-        <div>
-          <span>이름</span> <input type="text" value={member.name} disabled />
-        </div>
-        <div>
-          <span>연락처</span> <input type="text" value={member.contact} disabled />
-        </div>
-        <div>
-          <span>MBTI</span> <input type="text" value={member.mbti} disabled />
-        </div>
-      </FieldWrapper>
+        {/* 병합 후 수정 필요 */}
+        <FieldWrapper>
+          <FormInputField<EditFormInputs>
+            id="email"
+            label="이메일"
+            type="email"
+            placeholder="이메일을 입력해주세요"
+            register={register}
+            error={errors.email}
+          />
+          <FormInputField<EditFormInputs>
+            id="name"
+            label="이름"
+            placeholder="이름을 입력해주세요"
+            register={register}
+            error={errors.name}
+          />
+          <FormInputField<EditFormInputs>
+            id="phone"
+            label="연락처"
+            placeholder="010-1234-5678"
+            register={register}
+            error={errors.phone}
+          />
+          <FormSelectField<EditFormInputs>
+            id="mbti"
+            label="MBTI (선택 사항)"
+            register={register}
+            error={errors.mbti}
+            options={mbtiTypes}
+            placeholder="MBTI를 선택하세요"
+          />
+        </FieldWrapper>
 
-      <ControlBar>
-        <CancelButton onClick={closeModal}>취소</CancelButton>
-        <CompleteButton
-          onClick={() => {
-            console.log('회원 정보 수정 API 호출');
-          }}
-        >
-          수정
-        </CompleteButton>
-      </ControlBar>
-    </ModalWindowWrapper>
+        <ControlBar>
+          <CancelButton onClick={closeModal}>취소</CancelButton>
+          <CompleteButton type="submit" disabled={!isValid} onClick={() => {}}>
+            수정
+          </CompleteButton>
+        </ControlBar>
+      </ModalWindowWrapper>
+    </form>
   );
 }
 

--- a/src/pages/space/components/profile/PhotoEditWindow.tsx
+++ b/src/pages/space/components/profile/PhotoEditWindow.tsx
@@ -10,17 +10,22 @@ import {
   WindowTopBar,
 } from '@/pages/space/styles/modalWindowStyle';
 import Close from '@/assets/icons/Close';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { colorSystem } from '@/styles/colorSystem';
 
 function PhotoEditWindow({ closeModal }: ModalPropType) {
   const [preview, setPreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       setPreview(URL.createObjectURL(file));
     }
+  };
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
   };
 
   return (
@@ -33,14 +38,15 @@ function PhotoEditWindow({ closeModal }: ModalPropType) {
       </WindowTopBar>
 
       <PreviewDiv>{preview && <PreviewImage src={preview} alt="preview" />}</PreviewDiv>
-      <input id="photo-input" type="file" accept="image/*" hidden onChange={handleFileChange} />
-      <label htmlFor="photo-input">
-        <button>사진 업로드</button>
-      </label>
+      <input ref={fileInputRef} type="file" accept="image/*" hidden onChange={handleFileChange} />
+      <UploadButton type="button" onClick={handleUploadClick}>
+        사진 업로드
+      </UploadButton>
 
       <ControlBar>
         <CancelButton onClick={closeModal}>취소</CancelButton>
         <CompleteButton
+          disabled={preview === null}
           onClick={() => {
             console.log('회원 사진 수정 API 호출');
           }}
@@ -51,6 +57,17 @@ function PhotoEditWindow({ closeModal }: ModalPropType) {
     </ModalWindowWrapper>
   );
 }
+
+const UploadButton = styled.button`
+  width: 100%;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid ${colorSystem.primary_yellow._500};
+  background-color: ${colorSystem.tertiary_white._0};
+
+  transition: all 0.25s;
+  cursor: pointer;
+`;
 
 const PreviewDiv = styled.div`
   width: 100%;

--- a/src/pages/space/components/profile/Profile.tsx
+++ b/src/pages/space/components/profile/Profile.tsx
@@ -13,7 +13,7 @@ const dummyProfileResponse = {
     id: 1234,
     email: 'example@test.com',
     name: '홍길동',
-    contact: '+82-10-1234-1234',
+    contact: '010-1234-1234',
     mbti: 'ISTP',
   } as MemberType,
 };

--- a/src/pages/space/hooks/useEditForm.ts
+++ b/src/pages/space/hooks/useEditForm.ts
@@ -1,0 +1,28 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { editSchema, type EditFormInputs } from '../utils/editValidation';
+
+export const useEditForm = ({
+  defaultValues,
+  onSubmit,
+}: {
+  defaultValues: object;
+  onSubmit: (data: EditFormInputs) => void;
+}) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<EditFormInputs>({
+    resolver: zodResolver(editSchema),
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  return {
+    register,
+    handleSubmit: handleSubmit(onSubmit),
+    errors,
+    isValid,
+  };
+};

--- a/src/pages/space/styles/modalWindowStyle.ts
+++ b/src/pages/space/styles/modalWindowStyle.ts
@@ -37,12 +37,15 @@ export const ControlBar = styled.div`
   min-width: 300px;
 `;
 
-export const CompleteButton = styled.button`
+export const CompleteButton = styled.button<{ disabled: boolean }>`
   flex: 2;
   padding: 16px;
   border-radius: 8px;
   border: 1px solid ${colorSystem.primary_yellow._500};
-  background-color: ${colorSystem.tertiary_white._0};
+  background-color: ${({ disabled }) =>
+    disabled ? colorSystem.tertiary_white._0 : colorSystem.primary_yellow._500};
+
+  transition: all 0.25s;
   cursor: pointer;
 `;
 

--- a/src/pages/space/utils/editValidation.ts
+++ b/src/pages/space/utils/editValidation.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+export const mbtiTypes = [
+  'ISTJ',
+  'ISFJ',
+  'INFJ',
+  'INTJ',
+  'ISTP',
+  'ISFP',
+  'INFP',
+  'INTP',
+  'ESTP',
+  'ESFP',
+  'ENFP',
+  'ENTP',
+  'ESTJ',
+  'ESFJ',
+  'ENFJ',
+  'ENTJ',
+] as const;
+
+export const editSchema = z.object({
+  email: z
+    .string()
+    .min(1, { message: '이메일을 입력해주세요' })
+    .email({ message: '유효한 이메일 형식이 아닙니다' }),
+  name: z.string().min(1, { message: '이름을 입력해주세요' }),
+  phone: z
+    .string()
+    .min(1, { message: '연락처를 입력해주세요' })
+    .regex(/^010-\d{4}-\d{4}$/, {
+      message: '010-1234-5678 형식으로 입력해주세요',
+    }),
+
+  mbti: z.enum(mbtiTypes).optional().or(z.literal('')),
+});
+
+export type EditFormInputs = z.infer<typeof editSchema>;


### PR DESCRIPTION
# 개인 스페이스 페이지 - 회원 정보 수정 기능

## 설명

- **이 PR은 어떤 종류의 수정 사항인가요?** (버그 수정, 기능, 문서 업데이트 등)
기능 추가

- **상세 설명**

<img width="366" height="472" alt="image" src="https://github.com/user-attachments/assets/7d8f876f-dff0-49f1-be6d-dde04aa9ed9e" />

개인 스페이스 페이지의 회원 정보 수정 기능을 추가합니다.

<img width="358" height="376" alt="image" src="https://github.com/user-attachments/assets/720e1894-160f-45c3-a22f-192fc4a41ef0" />

회원 사진 수정 기능에서 파일 입력 창이 뜨지 않는 오류를 수정하였습니다.

@whyyhyh #12 에서 의견 주셨던 디자인 수정 사항이 이번 PR에 반영되었습니다.
