### PR TITLE
로그인, 회원가입 페이지 탑바 추가

### DIFF
--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -5,41 +5,44 @@ import { colorSystem } from '@/styles/colorSystem';
 import { useLoginForm } from './hooks/useLoginForm';
 import { FormInputField } from '@/components/FormInputField';
 import type { LoginFormInputs } from './utils/loginValidation';
+import TopBar from '@/components/TopBar';
 
 function LoginPage() {
   const { register, handleSubmit, errors, isValid, navigateToRegister } = useLoginForm();
 
   return (
     <Container>
-      <Logo src={logo} alt="logo" />
-      <Title>로그인</Title>
-      <StyledForm onSubmit={handleSubmit} noValidate>
-        <FormInputField<LoginFormInputs>
-          id="email"
-          label="이메일"
-          type="email"
-          placeholder="이메일을 입력해주세요"
-          register={register}
-          error={errors.email}
-        />
-        <FormInputField<LoginFormInputs>
-          id="password"
-          label="비밀번호"
-          type="password"
-          placeholder="비밀번호를 입력해주세요"
-          register={register}
-          error={errors.password}
-        />
-        <SignupGuide>
-          아직 계정이 없으신가요?{' '}
-          <SignupLink type="button" onClick={navigateToRegister}>
-            회원가입
-          </SignupLink>
-        </SignupGuide>
-        <LoginButton type="submit" disabled={!isValid}>
-          로그인
-        </LoginButton>
-      </StyledForm>
+      <TopBar>로그인</TopBar>
+      <Content>
+        <StyledForm onSubmit={handleSubmit} noValidate>
+          <Logo src={logo} alt="logo" />
+          <FormInputField<LoginFormInputs>
+            id="email"
+            label="이메일"
+            type="email"
+            placeholder="이메일을 입력해주세요"
+            register={register}
+            error={errors.email}
+          />
+          <FormInputField<LoginFormInputs>
+            id="password"
+            label="비밀번호"
+            type="password"
+            placeholder="비밀번호를 입력해주세요"
+            register={register}
+            error={errors.password}
+          />
+          <SignupGuide>
+            아직 계정이 없으신가요?{' '}
+            <SignupLink type="button" onClick={navigateToRegister}>
+              회원가입
+            </SignupLink>
+          </SignupGuide>
+          <LoginButton type="submit" disabled={!isValid}>
+            로그인
+          </LoginButton>
+        </StyledForm>
+      </Content>
     </Container>
   );
 }
@@ -48,19 +51,20 @@ const Container = styled.div`
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: white;
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: white;
+  flex-grow: 1;
 `;
 
 const Logo = styled.img`
   width: 80px;
   margin-bottom: 24px;
-`;
-
-const Title = styled.h2`
-  margin-bottom: 32px;
-  ${fontSystem.title.xlarge}
 `;
 
 const StyledForm = styled.form`

--- a/src/pages/register/RegisterPage.tsx
+++ b/src/pages/register/RegisterPage.tsx
@@ -6,6 +6,7 @@ import { fontSystem } from '@/styles/fontSystem';
 import { colorSystem } from '@/styles/colorSystem';
 import { useNavigate } from 'react-router-dom';
 import { FormSelectField } from '@/components/FormSelectField';
+import TopBar from '@/components/TopBar';
 
 function RegisterPage() {
   const { register, handleSubmit, errors, isValid } = useRegisterForm();
@@ -13,64 +14,66 @@ function RegisterPage() {
 
   return (
     <Container>
-      <Title>회원가입</Title>
-      <StyledForm onSubmit={handleSubmit} noValidate>
-        <FormInputField<RegisterFormInputs>
-          id="email"
-          label="이메일"
-          type="email"
-          placeholder="이메일을 입력해주세요"
-          register={register}
-          error={errors.email}
-        />
-        <FormInputField<RegisterFormInputs>
-          id="name"
-          label="이름"
-          placeholder="이름을 입력해주세요"
-          register={register}
-          error={errors.name}
-        />
-        <FormInputField<RegisterFormInputs>
-          id="password"
-          label="비밀번호"
-          type="password"
-          placeholder="영문, 숫자 포함 8자 이상"
-          register={register}
-          error={errors.password}
-        />
-        <FormInputField<RegisterFormInputs>
-          id="confirmPassword"
-          label="비밀번호 확인"
-          type="password"
-          placeholder="비밀번호를 다시 입력해주세요"
-          register={register}
-          error={errors.confirmPassword}
-        />
-        <FormInputField<RegisterFormInputs>
-          id="phone"
-          label="연락처"
-          placeholder="010-1234-5678"
-          register={register}
-          error={errors.phone}
-        />
-        <FormSelectField<RegisterFormInputs>
-          id="mbti"
-          label="MBTI (선택 사항)"
-          register={register}
-          error={errors.mbti}
-          options={mbtiTypes}
-          placeholder="MBTI를 선택하세요"
-        />
-        <SubmitButton type="submit" disabled={!isValid}>
-          가입하기
-        </SubmitButton>
-        <LoginGuide>
-          이미 계정이 있으신가요?{' '}
-          <LoginLink type="button" onClick={() => navigate('/login')}>
-            로그인
-          </LoginLink>
-        </LoginGuide>
-      </StyledForm>
+      <TopBar>회원가입</TopBar>
+      <Content>
+        <StyledForm onSubmit={handleSubmit} noValidate>
+          <FormInputField<RegisterFormInputs>
+            id="email"
+            label="이메일"
+            type="email"
+            placeholder="이메일을 입력해주세요"
+            register={register}
+            error={errors.email}
+          />
+          <FormInputField<RegisterFormInputs>
+            id="name"
+            label="이름"
+            placeholder="이름을 입력해주세요"
+            register={register}
+            error={errors.name}
+          />
+          <FormInputField<RegisterFormInputs>
+            id="password"
+            label="비밀번호"
+            type="password"
+            placeholder="영문, 숫자 포함 8자 이상"
+            register={register}
+            error={errors.password}
+          />
+          <FormInputField<RegisterFormInputs>
+            id="confirmPassword"
+            label="비밀번호 확인"
+            type="password"
+            placeholder="비밀번호를 다시 입력해주세요"
+            register={register}
+            error={errors.confirmPassword}
+          />
+          <FormInputField<RegisterFormInputs>
+            id="phone"
+            label="연락처"
+            placeholder="010-1234-5678"
+            register={register}
+            error={errors.phone}
+          />
+          <FormSelectField<RegisterFormInputs>
+            id="mbti"
+            label="MBTI (선택 사항)"
+            register={register}
+            error={errors.mbti}
+            options={mbtiTypes}
+            placeholder="MBTI를 선택하세요"
+          />
+          <SubmitButton type="submit" disabled={!isValid}>
+            가입하기
+          </SubmitButton>
+          <LoginGuide>
+            이미 계정이 있으신가요?{' '}
+            <LoginLink type="button" onClick={() => navigate('/login')}>
+              로그인
+            </LoginLink>
+          </LoginGuide>
+        </StyledForm>
+      </Content>
     </Container>
   );
 }
@@ -79,15 +82,16 @@ const Container = styled.div`
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 40px 20px;
   background: white;
 `;
 
-const Title = styled.h2`
-  margin-bottom: 32px;
-  ${fontSystem.title.xlarge}
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex-grow: 1;
+  padding: 40px 20px;
 `;
 
 const StyledForm = styled.form`


### PR DESCRIPTION
- 공통컴포넌트로 정의된 탑바를 로그인, 회원가입 페이지에 적용했습니다

# 로그인, 회원가입 페이지 탑바 추가

## 설명

- 탑 바 추가, UI 살짝 변경

- **상세 설명**
<img width="769" height="751" alt="image" src="https://github.com/user-attachments/assets/94c02131-94bf-4899-a98e-ed2f42cf17a9" />

<img width="762" height="855" alt="image" src="https://github.com/user-attachments/assets/dc59f23a-2a4b-4a2d-a4fb-54c6c71dd3f8" />

각 페이지에 공통 컴포넌트로 정의된 탑 바 추가했습니다.
로그인 페이지 로고이미지를 폼 내부로 넣었습니다.

- **기타 정보**:

<!--- 바로 아래에 이슈 링크를 추가해 주세요.-->
