### PR TITLE
스페이스 페이지 계획 삭제 버튼 추가

### DIFF
--- a/src/assets/icons/Delete.tsx
+++ b/src/assets/icons/Delete.tsx
@@ -1,0 +1,15 @@
+function Delete() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24px"
+      viewBox="0 -960 960 960"
+      width="24px"
+      fill="black"
+    >
+      <path d="M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm400-600H280v520h400v-520ZM360-280h80v-360h-80v360Zm160 0h80v-360h-80v360ZM280-720v520-520Z" />
+    </svg>
+  );
+}
+
+export default Delete;

--- a/src/pages/space/components/planspace/DeletionConfirmWindow.tsx
+++ b/src/pages/space/components/planspace/DeletionConfirmWindow.tsx
@@ -1,0 +1,109 @@
+import type { ModalPropType } from '@/hooks/useModal';
+import Close from '@/assets/icons/Close';
+import { styled } from 'styled-components';
+import { colorSystem } from '@/styles/colorSystem';
+import { fontSystem } from '@/styles/fontSystem';
+import type { PlanType } from '../../types/plan';
+
+function DeletionConfirmWindow({ closeModal, plan }: ModalPropType & { plan: PlanType }) {
+  const deletePlan = () => {
+    console.log(`API call for deleting plan ${plan.id}`);
+    closeModal();
+  };
+
+  return (
+    <ModalWindowWrapper>
+      <WindowTopBar>
+        <WindowTitle>이 계획을 삭제할까요?</WindowTitle>
+        <CloseButton onClick={closeModal}>
+          <Close />
+        </CloseButton>
+      </WindowTopBar>
+
+      <PlanWrapper>
+        <PlanTitle>{plan.title}</PlanTitle>
+        <PlanDescription>{plan.description}</PlanDescription>
+        <PlanDescription>
+          {plan.startDate}~{plan.endDate}
+        </PlanDescription>
+      </PlanWrapper>
+
+      <ControlBar>
+        <DeleteButton onClick={deletePlan}>삭제</DeleteButton>
+        <CancelButton onClick={closeModal}>취소</CancelButton>
+      </ControlBar>
+    </ModalWindowWrapper>
+  );
+}
+
+const PlanWrapper = styled.div`
+  border: 1px solid ${colorSystem.tertiary_white._900};
+  border-radius: 8px;
+  padding: 16px;
+`;
+
+const PlanTitle = styled.div`
+  ${fontSystem.title.large}
+`;
+
+const PlanDescription = styled.div`
+  ${fontSystem.body.medium}
+`;
+
+const WindowTopBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const WindowTitle = styled.div`
+  ${fontSystem.title.medium}
+`;
+
+const CloseButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+`;
+
+const ModalWindowWrapper = styled.div`
+  background-color: ${colorSystem.tertiary_white._0};
+  border-radius: 16px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const ControlBar = styled.div`
+  display: flex;
+  gap: 8px;
+  min-width: 300px;
+`;
+
+const DeleteButton = styled.button`
+  flex: 1;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid ${colorSystem.primary_yellow._500};
+  background-color: red;
+  color: white;
+
+  transition: all 0.25s;
+  cursor: pointer;
+`;
+
+const CancelButton = styled.button`
+  flex: 2;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid ${colorSystem.tertiary_white._900};
+  background-color: ${colorSystem.tertiary_white._0};
+  cursor: pointer;
+`;
+
+export default DeletionConfirmWindow;

--- a/src/pages/space/components/planspace/PlanCard.tsx
+++ b/src/pages/space/components/planspace/PlanCard.tsx
@@ -3,12 +3,19 @@ import type { PlanType } from '@/pages/space/types/plan';
 import { fontSystem } from '@/styles/fontSystem';
 import Edit from '@/assets/icons/Edit';
 import { usePageRouting } from '@/hooks/usePageRouting';
+import Delete from '@/assets/icons/Delete';
+import DeletionConfirmWindow from './DeletionConfirmWindow';
+import { useModal } from '@/hooks/useModal';
 
 function PlanCard({ plan, highlight = false }: { plan: PlanType; highlight?: boolean }) {
   const goto = usePageRouting();
-
+  const [deletionConfirmModal, openDeletionConfirmWindow] = useModal({
+    ModalWindow: DeletionConfirmWindow,
+    modalProps: { plan },
+  });
   return (
     <PlanCardWrapper highlight={highlight}>
+      {deletionConfirmModal}
       <HorizontalLayout>
         <PlanInfo>
           <PlanTitle>{plan.title}</PlanTitle>
@@ -17,13 +24,33 @@ function PlanCard({ plan, highlight = false }: { plan: PlanType; highlight?: boo
             {plan.startDate} ~ {plan.endDate}
           </PlanDate>
         </PlanInfo>
-        <EditButton onClick={goto.plan}>
-          <Edit />
-        </EditButton>
+        <ControlPanel>
+          <EditButton onClick={goto.plan}>
+            <Edit />
+          </EditButton>
+          <DeleteButton onClick={openDeletionConfirmWindow}>
+            <Delete />
+          </DeleteButton>
+        </ControlPanel>
       </HorizontalLayout>
     </PlanCardWrapper>
   );
 }
+
+const ControlPanel = styled.div`
+  display: flex;
+  justify-content: space-around;
+  gap: 20px;
+`;
+
+const DeleteButton = styled.button`
+  height: 100%;
+
+  background-color: transparent;
+  border: none;
+
+  cursor: pointer;
+`;
 
 const EditButton = styled.button`
   height: 100%;


### PR DESCRIPTION
# 스페이스 페이지 계획 삭제 버튼 추가

## 설명

- **이 PR은 어떤 종류의 수정 사항인가요?** (버그 수정, 기능, 문서 업데이트 등)
기능 추가

- **상세 설명**
스페이스 페이지 안에 위치하는 계획 카드에 삭제 버튼과 기능을 추가합니다.

- **기타 정보**:
계획 삭제시 확인 모달 띄움

- 삭제 버튼
<img width="734" height="170" alt="image" src="https://github.com/user-attachments/assets/0425b667-b712-4ef3-9307-9262e1537d3e" />

- 삭제 확인 모달
<img width="370" height="285" alt="image" src="https://github.com/user-attachments/assets/1343dbfb-1cb6-4dbd-84fe-c252c642a0c5" />
