### PR TITLE
PlanPage 라우팅 구조 개편, 서브페이지 추가

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -10,6 +10,10 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import ColorPanel from './ColorPanel';
 import FontPanel from './FontPanel';
 import { ToastContainer } from 'react-toastify';
+import WayPointPage from '@/pages/plan/subpages/WayPointPage';
+import TravelerPage from '@/pages/plan/subpages/TravelerPage';
+import MapPage from '@/pages/plan/subpages/MapPage';
+import MemoPage from '@/pages/plan/subpages/MemoPage';
 
 function Router() {
   return (
@@ -24,7 +28,12 @@ function Router() {
         <Route path={PATH.LOGIN} element={<LoginPage />} />
         <Route path={PATH.REGISTER} element={<RegisterPage />} />
         <Route path={PATH.SPACE} element={<SpacePage />} />
-        <Route path={PATH.PLAN} element={<PlanPage />} />
+        <Route path={PATH.PLAN.BASE} element={<PlanPage />}>
+          <Route path={PATH.PLAN.WAYPOINT} element={<WayPointPage />} />
+          <Route path={PATH.PLAN.TRAVELER} element={<TravelerPage />} />
+          <Route path={PATH.PLAN.MAP} element={<MapPage />} />
+          <Route path={PATH.PLAN.MEMO} element={<MemoPage />} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/RoutingPanel.tsx
+++ b/src/components/RoutingPanel.tsx
@@ -13,7 +13,7 @@ function RoutingPanel() {
         <Button onClick={goto.login}>로그인</Button>
         <Button onClick={goto.register}>회원가입</Button>
         <Button onClick={goto.space}>스페이스</Button>
-        <Button onClick={goto.plan}>계획</Button>
+        <Button onClick={goto.plan.base('1234').waypoint}>계획</Button>
       </div>
     </RoutingPanelWrapper>
   );

--- a/src/hooks/usePageRouting.ts
+++ b/src/hooks/usePageRouting.ts
@@ -12,7 +12,16 @@ export const usePageRouting = () => {
       login: () => navigate(PATH.LOGIN),
       register: () => navigate(PATH.REGISTER),
       space: () => navigate(PATH.SPACE),
-      plan: () => navigate(PATH.PLAN),
+      plan: {
+        base: (id: string) => {
+          return {
+            waypoint: () => navigate(PATH.PLAN.WAYPOINT.replace(':id', id)),
+            traveler: () => navigate(PATH.PLAN.TRAVELER.replace(':id', id)),
+            map: () => navigate(PATH.PLAN.MAP.replace(':id', id)),
+            memo: () => navigate(PATH.PLAN.MEMO.replace(':id', id)),
+          };
+        },
+      },
       back: () => navigate(-1),
       //plan: (planId: string) => navigate(PATH.PLAN.replace(":planId", planId)),
     }),

--- a/src/pages/plan/PlanPage.tsx
+++ b/src/pages/plan/PlanPage.tsx
@@ -1,5 +1,43 @@
+import { usePageRouting } from '@/hooks/usePageRouting';
+import { fontSystem } from '@/styles/fontSystem';
+import { Outlet, useParams } from 'react-router-dom';
+import { styled } from 'styled-components';
+
 function PlanPage() {
-  return <>PlanPage</>;
+  const goto = usePageRouting();
+  const id = useParams().id ?? '-1';
+  return (
+    <>
+      <TitleBar>
+        <Title>일본여행</Title>
+        <Description>OOO과 함께하는 일본 여행</Description>
+      </TitleBar>
+      <button onClick={goto.plan.base(id).waypoint}>웨이포인트 관리</button>
+      <button onClick={goto.plan.base(id).traveler}>여행자 관리</button>
+      <button onClick={goto.plan.base(id).map}>지도</button>
+      <button onClick={goto.plan.base(id).memo}>메모</button>
+      <div>
+        <Outlet />
+      </div>
+    </>
+  );
 }
+
+const Title = styled.div`
+  ${fontSystem.title.xxlarge}
+  margin-right: 8px;
+`;
+
+const Description = styled.div`
+  ${fontSystem.body.large}
+`;
+
+const TitleBar = styled.div`
+  padding: 16px;
+  display: flex;
+
+  align-items: baseline;
+  flex-wrap: wrap;
+`;
 
 export default PlanPage;

--- a/src/pages/plan/subpages/MapPage.tsx
+++ b/src/pages/plan/subpages/MapPage.tsx
@@ -1,0 +1,5 @@
+function MapPage() {
+  return <>MapPage</>;
+}
+
+export default MapPage;

--- a/src/pages/plan/subpages/MemoPage.tsx
+++ b/src/pages/plan/subpages/MemoPage.tsx
@@ -1,0 +1,5 @@
+function MemoPage() {
+  return <>MemoPage</>;
+}
+
+export default MemoPage;

--- a/src/pages/plan/subpages/TravelerPage.tsx
+++ b/src/pages/plan/subpages/TravelerPage.tsx
@@ -1,0 +1,5 @@
+function TravelerPage() {
+  return <>TravelerPage</>;
+}
+
+export default TravelerPage;

--- a/src/pages/plan/subpages/WayPointPage.tsx
+++ b/src/pages/plan/subpages/WayPointPage.tsx
@@ -1,0 +1,5 @@
+function WayPointPage() {
+  return <>WayPointPage</>;
+}
+
+export default WayPointPage;

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,3 +1,7 @@
+const BASE = {
+  PLAN: '/plan/:id',
+};
+
 export const PATH = {
   ROOT: '/',
   LANDING: '/',
@@ -5,5 +9,11 @@ export const PATH = {
   LOGIN: '/login',
   REGISTER: '/register',
   SPACE: '/space',
-  PLAN: '/plan',
+  PLAN: {
+    BASE: BASE.PLAN,
+    WAYPOINT: `${BASE.PLAN}/waypoint`,
+    TRAVELER: `${BASE.PLAN}/traveler`,
+    MAP: `${BASE.PLAN}/map`,
+    MEMO: `${BASE.PLAN}/memo`,
+  },
 };


### PR DESCRIPTION
# PlanPage 라우팅 개선 및 서브페이지 추가

## 설명

- **이 PR은 어떤 종류의 수정 사항인가요?** (버그 수정, 기능, 문서 업데이트 등)

기능

- **상세 설명**  

- Router.tsx에 plan 하위 라우트를 PATH.PLAN.BASE 아래 중첩하도록 수정
- WayPointPage, TravelerPage, MapPage, MemoPage 컴포넌트 추가
- usePageRouting 훅을 수정하여 동적 plan/:id 경로 지원
- PlanPage에서 useParams로 id를 받아 <Outlet />을 통해 서브페이지 렌더링하도록 변경
- PATH 상수를 plan base 및 하위 라우트 구조로 리팩터링
