### PR TITLE
스페이스 페이지: 새 계획 생성 버튼

### DIFF
--- a/src/assets/icons/Add.tsx
+++ b/src/assets/icons/Add.tsx
@@ -1,0 +1,15 @@
+function Add() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24px"
+      viewBox="0 -960 960 960"
+      width="24px"
+      fill="black"
+    >
+      <path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z" />
+    </svg>
+  );
+}
+
+export default Add;

--- a/src/components/FormInputField.tsx
+++ b/src/components/FormInputField.tsx
@@ -6,7 +6,7 @@ import { colorSystem } from '@/styles/colorSystem';
 interface FormInputFieldProps<TFormValues extends Record<string, unknown>> {
   id: Path<TFormValues>;
   label: string;
-  type?: 'text' | 'email' | 'password';
+  type?: 'text' | 'email' | 'password' | 'date';
   placeholder?: string;
   register: UseFormRegister<TFormValues>;
   error?: FieldError;

--- a/src/pages/space/components/planspace/NewPlanWindow.tsx
+++ b/src/pages/space/components/planspace/NewPlanWindow.tsx
@@ -1,0 +1,89 @@
+import type { ModalPropType } from '@/hooks/useModal';
+import Close from '@/assets/icons/Close';
+import {
+  CancelButton,
+  CloseButton,
+  CompleteButton,
+  ControlBar,
+  ModalWindowWrapper,
+  WindowTitle,
+  WindowTopBar,
+} from '@/pages/space/styles/modalWindowStyle';
+import { styled } from 'styled-components';
+import { FormInputField } from '@/components/FormInputField';
+import { useNewPlanForm } from '../../hooks/useNewPlanForm';
+import type { NewPlanFormInputs } from '../../utils/planValidation';
+
+function NewPlanWindow({ closeModal }: ModalPropType) {
+  const { register, handleSubmit, errors, isValid } = useNewPlanForm({
+    defaultValues: {},
+    onSubmit: (data: NewPlanFormInputs) => {
+      // todo: POST API 호출
+      console.log('서버로 전송할 데이터:', data);
+      alert('새로운 계획을 만들었습니다.');
+      closeModal();
+    },
+  });
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      <ModalWindowWrapper>
+        <WindowTopBar>
+          <WindowTitle>새 여행 계획 만들기</WindowTitle>
+          <CloseButton onClick={closeModal}>
+            <Close />
+          </CloseButton>
+        </WindowTopBar>
+
+        <FieldWrapper>
+          <FormInputField<NewPlanFormInputs>
+            id="title"
+            label="제목"
+            type="email"
+            placeholder="여행 제목을 입력해주세요"
+            register={register}
+            error={errors.title}
+          />
+          <FormInputField<NewPlanFormInputs>
+            id="description"
+            label="설명"
+            placeholder="여행 설명을 입력해주세요"
+            register={register}
+            error={errors.description}
+          />
+          <FormInputField<NewPlanFormInputs>
+            id="startDate"
+            label="시작일"
+            placeholder="여행 설명을 입력해주세요"
+            register={register}
+            error={errors.startDate}
+            type="date"
+          />
+          <FormInputField<NewPlanFormInputs>
+            id="endDate"
+            label="종료일"
+            placeholder="여행 설명을 입력해주세요"
+            register={register}
+            error={errors.endDate}
+            type="date"
+          />
+        </FieldWrapper>
+
+        <ControlBar>
+          <CancelButton onClick={closeModal}>취소</CancelButton>
+          <CompleteButton type="submit" disabled={!isValid} onClick={() => {}}>
+            수정
+          </CompleteButton>
+        </ControlBar>
+      </ModalWindowWrapper>
+    </form>
+  );
+}
+
+const FieldWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export default NewPlanWindow;

--- a/src/pages/space/components/planspace/NewPlanWindow.tsx
+++ b/src/pages/space/components/planspace/NewPlanWindow.tsx
@@ -39,7 +39,6 @@ function NewPlanWindow({ closeModal }: ModalPropType) {
           <FormInputField<NewPlanFormInputs>
             id="title"
             label="제목"
-            type="email"
             placeholder="여행 제목을 입력해주세요"
             register={register}
             error={errors.title}
@@ -54,7 +53,6 @@ function NewPlanWindow({ closeModal }: ModalPropType) {
           <FormInputField<NewPlanFormInputs>
             id="startDate"
             label="시작일"
-            placeholder="여행 설명을 입력해주세요"
             register={register}
             error={errors.startDate}
             type="date"
@@ -62,7 +60,6 @@ function NewPlanWindow({ closeModal }: ModalPropType) {
           <FormInputField<NewPlanFormInputs>
             id="endDate"
             label="종료일"
-            placeholder="여행 설명을 입력해주세요"
             register={register}
             error={errors.endDate}
             type="date"
@@ -72,7 +69,7 @@ function NewPlanWindow({ closeModal }: ModalPropType) {
         <ControlBar>
           <CancelButton onClick={closeModal}>취소</CancelButton>
           <CompleteButton type="submit" disabled={!isValid} onClick={() => {}}>
-            수정
+            완료
           </CompleteButton>
         </ControlBar>
       </ModalWindowWrapper>

--- a/src/pages/space/components/planspace/NewPlanWindow.tsx
+++ b/src/pages/space/components/planspace/NewPlanWindow.tsx
@@ -11,8 +11,8 @@ import {
 } from '@/pages/space/styles/modalWindowStyle';
 import { styled } from 'styled-components';
 import { FormInputField } from '@/components/FormInputField';
-import { useNewPlanForm } from '../../hooks/useNewPlanForm';
-import type { NewPlanFormInputs } from '../../utils/planValidation';
+import { useNewPlanForm } from '@/pages/space/hooks/useNewPlanForm';
+import type { NewPlanFormInputs } from '@/pages/space/utils/planValidation';
 
 function NewPlanWindow({ closeModal }: ModalPropType) {
   const { register, handleSubmit, errors, isValid } = useNewPlanForm({

--- a/src/pages/space/components/planspace/PlanSpace.tsx
+++ b/src/pages/space/components/planspace/PlanSpace.tsx
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import type { PlanType } from '@/pages/space/types/plan';
 import PlanCard from './PlanCard';
 import Add from '@/assets/icons/Add';
+import NewPlanWindow from './NewPlanWindow';
+import { useModal } from '@/hooks/useModal';
 
 const dummyPlanResponse = {
   status: 200,
@@ -32,17 +34,18 @@ const dummyPlanResponse = {
 
 function PlanSpace() {
   const plans = dummyPlanResponse.plans;
-  // 가장 최근 수정한 플랜을 highlight하면 어떻까요?
-  const handleAddNewPlan = () => {
-    console.log('새 계획 생성 API 호출');
-  };
+
+  const [newPlanWindow, openNewPlanModal] = useModal({
+    ModalWindow: NewPlanWindow,
+  });
 
   return (
     <PlanSpaceWrapper>
+      {newPlanWindow}
       {plans.map((plan: PlanType) => {
         return <PlanCard key={plan.id} plan={plan} highlight={plan.id === 1234} />;
       })}
-      <AddButton onClick={handleAddNewPlan}>
+      <AddButton onClick={openNewPlanModal}>
         <Add />새 여행 계획하기
       </AddButton>
     </PlanSpaceWrapper>

--- a/src/pages/space/components/planspace/PlanSpace.tsx
+++ b/src/pages/space/components/planspace/PlanSpace.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import type { PlanType } from '@/pages/space/types/plan';
 import PlanCard from './PlanCard';
+import Add from '@/assets/icons/Add';
 
 const dummyPlanResponse = {
   status: 200,
@@ -32,14 +33,34 @@ const dummyPlanResponse = {
 function PlanSpace() {
   const plans = dummyPlanResponse.plans;
   // 가장 최근 수정한 플랜을 highlight하면 어떻까요?
+  const handleAddNewPlan = () => {
+    console.log('새 계획 생성 API 호출');
+  };
+
   return (
     <PlanSpaceWrapper>
       {plans.map((plan: PlanType) => {
         return <PlanCard key={plan.id} plan={plan} highlight={plan.id === 1234} />;
       })}
+      <AddButton onClick={handleAddNewPlan}>
+        <Add />새 여행 계획하기
+      </AddButton>
     </PlanSpaceWrapper>
   );
 }
+
+const AddButton = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  padding: 20px;
+
+  border-radius: 16px;
+  box-shadow: 0 2px 12px rgba(255, 192, 77, 0.3);
+
+  cursor: pointer;
+`;
 
 const PlanSpaceWrapper = styled.div`
   display: grid;

--- a/src/pages/space/hooks/useNewPlanForm.ts
+++ b/src/pages/space/hooks/useNewPlanForm.ts
@@ -1,0 +1,28 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { planSchema, type NewPlanFormInputs } from '../utils/planValidation';
+
+export const useNewPlanForm = ({
+  defaultValues,
+  onSubmit,
+}: {
+  defaultValues: object;
+  onSubmit: (data: NewPlanFormInputs) => void;
+}) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<NewPlanFormInputs>({
+    resolver: zodResolver(planSchema),
+    mode: 'onChange',
+    defaultValues,
+  });
+
+  return {
+    register,
+    handleSubmit: handleSubmit(onSubmit),
+    errors,
+    isValid,
+  };
+};

--- a/src/pages/space/utils/planValidation.ts
+++ b/src/pages/space/utils/planValidation.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const planSchema = z
+  .object({
+    title: z.string().min(1, { message: '제목을 입력해주세요' }),
+    description: z.string().min(1, { message: '설명을 입력해주세요' }),
+    startDate: z.string().min(1, { message: '시작 날짜를 선택해주세요' }),
+    endDate: z.string().min(1, { message: '종료 날짜를 선택해주세요' }),
+  })
+  .refine(
+    (data) => {
+      const start = new Date(data.startDate);
+      const end = new Date(data.endDate);
+      return !isNaN(start.getTime()) && !isNaN(end.getTime()) && start < end;
+    },
+    {
+      message: '종료일은 시작일보다 이후여야 합니다',
+      path: ['endDate'],
+    }
+  );
+
+export type NewPlanFormInputs = z.infer<typeof planSchema>;


### PR DESCRIPTION
# 스페이스 페이지: 새 계획 생성 버튼

## 설명

- **이 PR은 어떤 종류의 수정 사항인가요?** (버그 수정, 기능, 문서 업데이트 등)

기능

## 상세 설명

- 스페이스 페이지 버튼 추가
  - 새 계획 추가 버튼

- 여행 계획 모달 추가
  - 새로운 여행 계획을 위한 `NewPlanWindow` 컴포넌트 추가
  - zod 기반 유효성 검증을 적용한 `useNewPlanForm` 훅 생성
  - `planValidation` 스키마 정의 (제목/설명 필수, 시작일 < 종료일 검증)
  - `FormInputField`에 date 타입 지원 추가
  - PlanSpace에서 "새 여행 계획하기" 버튼을 모달 열기로 연결
  
## 새 계획 추가 버튼 UI

<img width="755" height="992" alt="image" src="https://github.com/user-attachments/assets/9d89238a-4bd1-4cc3-85b3-b36475aa0a8c" />

## 모달 창 UI

<img width="400" height="516" alt="image" src="https://github.com/user-attachments/assets/43fd8e6a-28d1-485e-8cf6-1df3bfbf3cc6" />

## 유효성 검증

<img width="376" height="537" alt="image" src="https://github.com/user-attachments/assets/079f995e-2afd-4825-9839-05acf535a431" />
