### PR TITLE
[김성진] AuthContext의 이벤트리스너 캐스팅 제거

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -39,23 +39,20 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
 
     // 동일 탭 내에서 axiosInstance의 토큰 변경을 감지하기 위한 브라우저 이벤트 리스너 설정
-    const handleRefreshed = (e: Event) => {
-      const detail = (
-        e as CustomEvent<{ accessToken: string | null; refreshToken?: string | null }>
-      ).detail;
-      if (detail?.accessToken !== undefined) setAccessToken(detail.accessToken);
-      if (detail?.refreshToken !== undefined && detail.refreshToken !== null)
-        setRefreshToken(detail.refreshToken);
+    const handleRefreshed = (e: WindowEventMap['auth:tokenRefreshed']) => {
+      const { accessToken, refreshToken } = e.detail ?? {};
+      if (accessToken !== undefined) setAccessToken(accessToken);
+      if (refreshToken !== undefined && refreshToken !== null) setRefreshToken(refreshToken);
     };
-    const handleCleared = () => {
+    const handleCleared = (_e: WindowEventMap['auth:tokensCleared']) => {
       setAccessToken(null);
       setRefreshToken(null);
       setUser(null);
     };
-    window.addEventListener('auth:tokenRefreshed', handleRefreshed as EventListener);
+    window.addEventListener('auth:tokenRefreshed', handleRefreshed);
     window.addEventListener('auth:tokensCleared', handleCleared);
     return () => {
-      window.removeEventListener('auth:tokenRefreshed', handleRefreshed as EventListener);
+      window.removeEventListener('auth:tokenRefreshed', handleRefreshed);
       window.removeEventListener('auth:tokensCleared', handleCleared);
     };
   }, []);

--- a/src/types/auth-events.d.ts
+++ b/src/types/auth-events.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  interface WindowEventMap {
+    'auth:tokenRefreshed': CustomEvent<{
+      accessToken: string | null;
+      refreshToken?: string | null;
+    }>;
+    'auth:tokensCleared': Event;
+  }
+}
+export {};


### PR DESCRIPTION
# AuthContext의 이벤트리스너 캐스팅 제거

## 설명

저번주 PR의 피드백 적용 내용입니다.

- 커스텀 이벤트를 WindowEventMap에 전역선언해 핸들러를 정확히 타이핑하고, as EventListener 캐스팅을 제거하여 타입 안전성과 가독성을 높였습니다

-axiosInstance.ts 파일에서 promise 따로 변수형태로 관리하는 이유는 401 동시 에러가 터졌을 때 이를 단일화 하여 리프레시요청을 1회로 제한하고 결과를 기다리도록 하게 만들기 위해서입니다! 
