### PR TITLE
[박수민] Props 타입 분리 및 프롭 타입 명시

### DIFF
--- a/src/pages/space/components/planspace/NewPlanWindow.tsx
+++ b/src/pages/space/components/planspace/NewPlanWindow.tsx
@@ -16,7 +16,6 @@ import type { NewPlanFormInputs } from '@/pages/space/utils/planValidation';
 
 function NewPlanWindow({ closeModal }: ModalPropType) {
   const { register, handleSubmit, errors, isValid } = useNewPlanForm({
-    defaultValues: {},
     onSubmit: (data: NewPlanFormInputs) => {
       // todo: POST API 호출
       console.log('서버로 전송할 데이터:', data);

--- a/src/pages/space/hooks/useNewPlanForm.ts
+++ b/src/pages/space/hooks/useNewPlanForm.ts
@@ -2,13 +2,12 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { planSchema, type NewPlanFormInputs } from '../utils/planValidation';
 
-export const useNewPlanForm = ({
-  defaultValues,
-  onSubmit,
-}: {
-  defaultValues: object;
+type UseNewPlanFormProps = {
+  defaultValues?: NewPlanFormInputs;
   onSubmit: (data: NewPlanFormInputs) => void;
-}) => {
+};
+
+export const useNewPlanForm = ({ defaultValues, onSubmit }: UseNewPlanFormProps) => {
   const {
     register,
     handleSubmit,


### PR DESCRIPTION
#  Props 타입 분리 및 프롭 타입 명시

## 설명

- **이 PR은 어떤 종류의 수정 사항인가요?** (버그 수정, 기능, 문서 업데이트 등)

리뷰 피드백 수용 리펙토링

- **상세 설명**

안녕하세요 멘토님

이전 PR https://github.com/kakao-tech-campus-3rd-step3/Team8_FE/pull/35
에서 피드백 받았던 부분중 프롭 타입 분리와 defaultValues 타입 명시에 부분에 대한 리펙토링 PR을 리뷰 요청드립니다!

- useNewPlanForm 훅 프롭 타입 분리 -> UseNewPlanFormProps
- defaultValues 타입 명시

## 추가 질문

PR에 멘토님이 남기셨던 코멘트중 아래와 같은 부분이 있었는데,
> object 타입은 사실상 any타입에 가깝게 사용하는 부분입니다.
object 타입을 사용하신 이유가 있을까요?
정말로 모든 타입이 넘어올 수 있는 상황이 아니라면 타입을 좁힐 필요가 있어보입니다.

이 상황에서 타입을 좁히지 않는 경우 어떤 사이드 이펙트가 있을 수 있는지 궁금합니다!