### PR TITLE
로그인/회원가입 API 요청 기능 구현

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -38,9 +38,23 @@ axiosInstance.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
-// 응답이 401(만료/인증실패)이면 refresh 시도 후 원래 요청 재시도
+// 응답이 401(만료/인증실패)이면 refresh 시도 후 원요청 재시도
 let isRefreshing = false;
-let refreshPromise: Promise<string | null> | null = null;
+let refreshSubscribers: Array<(token: string | null) => void> = [];
+
+function subscribeTokenRefresh(cb: (token: string | null) => void) {
+  refreshSubscribers.push(cb);
+}
+
+function notifyTokenRefreshed(token: string | null) {
+  const subs = refreshSubscribers;
+  refreshSubscribers = [];
+  subs.forEach((cb) => {
+    try {
+      cb(token);
+    } catch {}
+  });
+}
 
 async function refreshAccessToken(): Promise<string | null> {
   const refresh = getRefreshToken();
@@ -65,6 +79,9 @@ async function refreshAccessToken(): Promise<string | null> {
       );
     } catch {}
 
+    // 구독자들에게 새 토큰 전달
+    notifyTokenRefreshed(newAccess ?? null);
+
     return newAccess ?? null;
   } catch (e) {
     // Refresh 실패시 토큰 제거
@@ -72,6 +89,8 @@ async function refreshAccessToken(): Promise<string | null> {
     try {
       window.dispatchEvent(new Event('auth:tokensCleared'));
     } catch {}
+    // 구독자들에게 실패 전달(null)
+    notifyTokenRefreshed(null);
     return null;
   }
 }
@@ -84,23 +103,36 @@ axiosInstance.interceptors.response.use(
 
     if (response?.status === 401 && originalRequest && !originalRequest._retry) {
       originalRequest._retry = true;
-
-      if (!isRefreshing) {
-        isRefreshing = true;
-        refreshPromise = refreshAccessToken().finally(() => {
-          isRefreshing = false;
+      if (isRefreshing) {
+        // 이미 리프레시 중: 새 Promise를 만들어 결과를 구독
+        return new Promise((resolve, reject) => {
+          subscribeTokenRefresh((newAccess) => {
+            if (newAccess) {
+              originalRequest.headers = {
+                ...(originalRequest.headers || {}),
+                Authorization: `Bearer ${newAccess}`,
+              } as any;
+              resolve(axiosInstance(originalRequest));
+            } else {
+              reject(error);
+            }
+          });
         });
-      }
-
-      const newAccess = await (refreshPromise as Promise<string | null>);
-
-      if (newAccess) {
-        // 토큰 교체 후 재시도
-        originalRequest.headers = {
-          ...(originalRequest.headers || {}),
-          Authorization: `Bearer ${newAccess}`,
-        } as any;
-        return axiosInstance(originalRequest);
+      } else {
+        // 최초 한 번만 실제 리프레시 호출
+        isRefreshing = true;
+        try {
+          const newAccess = await refreshAccessToken();
+          if (newAccess) {
+            originalRequest.headers = {
+              ...(originalRequest.headers || {}),
+              Authorization: `Bearer ${newAccess}`,
+            } as any;
+            return axiosInstance(originalRequest);
+          }
+        } finally {
+          isRefreshing = false;
+        }
       }
     }
 

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -27,13 +27,15 @@ const clearTokens = () => {
 };
 
 // 로그인/회원가입은 Authorization 헤더 제외 대상 (member권한 필요없음)
-const AUTH_EXCLUDED_PATHS = new Set<string>(['/v1/members/login', '/v1/members/signup']);
+const AUTH_EXCLUDED_LIST = ['/v1/members/login', '/v1/members/signup'] as const;
+type AuthExcludedPath = (typeof AUTH_EXCLUDED_LIST)[number];
+const AUTH_EXCLUDED_PATHS = new Set<AuthExcludedPath>(AUTH_EXCLUDED_LIST);
 
 function isAuthExcluded(url?: string) {
   if (!url) return false;
   try {
     const u = url.startsWith('http') ? new URL(url) : new URL(url, API_BASE_URL);
-    return AUTH_EXCLUDED_PATHS.has(u.pathname);
+    return AUTH_EXCLUDED_PATHS.has(u.pathname as AuthExcludedPath);
   } catch {
     return false;
   }
@@ -52,7 +54,7 @@ axiosInstance.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
-// 응답이 401(만료/인증실패)이면 refresh 시도 후 원요청 재시도
+// 응답이 401(만료/인증실패)이면 refresh 시도 후 원래 요청 재시도
 let isRefreshing = false;
 let refreshSubscribers: Array<(token: string | null) => void> = [];
 

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -26,11 +26,25 @@ const clearTokens = () => {
   localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
 };
 
+// 로그인/회원가입은 Authorization 헤더 제외 대상 (member권한 필요없음)
+const AUTH_EXCLUDED_PATHS = new Set<string>(['/v1/members/login', '/v1/members/signup']);
+
+function isAuthExcluded(url?: string) {
+  if (!url) return false;
+  try {
+    const u = url.startsWith('http') ? new URL(url) : new URL(url, API_BASE_URL);
+    return AUTH_EXCLUDED_PATHS.has(u.pathname);
+  } catch {
+    return false;
+  }
+}
+
 // 매 요청에 access token 헤더를 자동으로 붙임
 axiosInstance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     const access = getAccessToken();
-    if (access) {
+    const skipAuth = isAuthExcluded(config.url);
+    if (access && !skipAuth) {
       config.headers.Authorization = `Bearer ${access}`;
     }
     return config;
@@ -62,7 +76,7 @@ async function refreshAccessToken(): Promise<string | null> {
 
   try {
     const res = await axios.post(
-      `${API_BASE_URL}/auth/refresh`, // 리프레시 엔드포인트가 어떻게 될지 모르겠어서 임시로 이렇게 했습니다.
+      `${API_BASE_URL}/v1/members/refresh`, // 리프레시 엔드포인트 수정 완료
       { refreshToken: refresh }, // 이부분도 API 스펙에 맞게 조정 필요합니다.
       { headers: { 'Content-Type': 'application/json' } }
     );

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1,0 +1,11 @@
+const API_PREFIX = '/v1' as const; //api 프리픽스 수정시 이곳만 수정
+
+export const ENDPOINTS = {
+  members: {
+    login: `${API_PREFIX}/members/login`,
+    signup: `${API_PREFIX}/members/signup`,
+    me: `${API_PREFIX}/members/me`,
+  },
+} as const;
+
+export type Endpoints = typeof ENDPOINTS;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,42 +1,28 @@
 import { createContext, useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
-import { type MemberType } from '@/types/member';
 import { STORAGE_KEYS } from '@/utils/storageKeys';
 
-type User = MemberType;
-
 interface AuthContextType {
-  user: User | null;
   accessToken: string | null;
   refreshToken: string | null;
   isAuthenticated: boolean;
-  login: (params: { accessToken: string; refreshToken: string; user: User }) => void;
+  login: (params: { accessToken: string; refreshToken: string }) => void;
   logout: () => void;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const [user, setUser] = useState<User | null>(null);
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState<string | null>(null);
 
   useEffect(() => {
-    // localStorage에서 토큰과 유저 정보 불러오기
+    // localStorage에서 토큰 불러오기
     const storedAccess = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
     const storedRefresh = localStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
-    const storedUser = localStorage.getItem(STORAGE_KEYS.AUTH_USER);
 
     if (storedAccess) setAccessToken(storedAccess);
     if (storedRefresh) setRefreshToken(storedRefresh);
-    if (storedUser) {
-      try {
-        setUser(JSON.parse(storedUser));
-      } catch (error) {
-        console.error('Failed to parse auth user from localStorage', error);
-        localStorage.removeItem(STORAGE_KEYS.AUTH_USER);
-      }
-    }
 
     // 동일 탭 내에서 axiosInstance의 토큰 변경을 감지하기 위한 브라우저 이벤트 리스너 설정
     const handleRefreshed = (e: WindowEventMap['auth:tokenRefreshed']) => {
@@ -47,7 +33,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const handleCleared = (_e: WindowEventMap['auth:tokensCleared']) => {
       setAccessToken(null);
       setRefreshToken(null);
-      setUser(null);
     };
     window.addEventListener('auth:tokenRefreshed', handleRefreshed);
     window.addEventListener('auth:tokensCleared', handleCleared);
@@ -57,26 +42,21 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     };
   }, []);
 
-  const login: AuthContextType['login'] = ({ accessToken, refreshToken, user }) => {
+  const login: AuthContextType['login'] = ({ accessToken, refreshToken }) => {
     setAccessToken(accessToken);
     setRefreshToken(refreshToken);
-    setUser(user);
     localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, accessToken);
     localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
-    localStorage.setItem(STORAGE_KEYS.AUTH_USER, JSON.stringify(user));
   };
 
   const logout = () => {
     setAccessToken(null);
     setRefreshToken(null);
-    setUser(null);
     localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN);
     localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
-    localStorage.removeItem(STORAGE_KEYS.AUTH_USER);
   };
 
   const value: AuthContextType = {
-    user,
     accessToken,
     refreshToken,
     isAuthenticated: !!accessToken,

--- a/src/hooks/useApiError.ts
+++ b/src/hooks/useApiError.ts
@@ -1,0 +1,132 @@
+import axios, { type AxiosError } from 'axios';
+
+export type AppErrorType =
+  | 'auth' // 401 (실제 처리는 axiosInstance에서 처리)
+  | 'validation' // 400
+  | 'not_found' // 404
+  | 'client' // 그 외 4xx (401/404 제외)
+  | 'server' // 5xx 전체
+  | 'network' // 네트워크/타임아웃
+  | 'cancelled' // 요청 취소
+  | 'unknown';
+
+export interface AppError {
+  type: AppErrorType;
+  status?: number;
+  code?: string;
+  message: string;
+  fieldErrors?: Record<string, string>;
+  raw?: unknown;
+}
+
+interface UseApiErrorOptions {
+  // 각 페이지별 커스터마이즈 기능
+  codeMessages?: Record<string, string>;
+  typeMessages?: Partial<Record<AppErrorType, string>>;
+  onAnyError?: (err: AppError) => void;
+}
+
+function normalizeAxiosError(e: unknown, opts?: UseApiErrorOptions): AppError {
+  if (axios.isAxiosError(e)) {
+    const err = e as AxiosError<any>;
+    const status = err.response?.status;
+    const data = err.response?.data as any | undefined;
+    const serverCode = (data && typeof data === 'object' ? data.code : undefined) as
+      | string
+      | undefined;
+    const serverMsg =
+      (data && typeof data === 'object' ? (data.message as string | undefined) : undefined) ||
+      err.message;
+
+    const byCodeMsg = serverCode ? opts?.codeMessages?.[serverCode] : undefined;
+
+    if (status === 401) {
+      return {
+        type: 'auth',
+        status,
+        code: serverCode,
+        message: byCodeMsg ?? opts?.typeMessages?.auth ?? '인증이 필요합니다.',
+        raw: e,
+      };
+    }
+    if (status === 404) {
+      return {
+        type: 'not_found',
+        status,
+        code: serverCode,
+        message: byCodeMsg ?? opts?.typeMessages?.not_found ?? '대상을 찾을 수 없습니다.',
+        raw: e,
+      };
+    }
+    if (status === 400) {
+      const fieldErrors =
+        (data && typeof data === 'object'
+          ? (data.fieldErrors as Record<string, string>)
+          : undefined) || undefined;
+      const baseMsg = fieldErrors ? '입력값을 확인해주세요.' : '잘못된 요청입니다.';
+      return {
+        type: fieldErrors ? 'validation' : 'unknown',
+        status,
+        code: serverCode,
+        message: byCodeMsg ?? opts?.typeMessages?.validation ?? serverMsg ?? baseMsg,
+        fieldErrors,
+        raw: e,
+      };
+    }
+    if (typeof status === 'number' && status >= 500) {
+      return {
+        type: 'server',
+        status,
+        code: serverCode,
+        message: byCodeMsg ?? opts?.typeMessages?.server ?? '서버 오류가 발생했습니다.',
+        raw: e,
+      };
+    }
+
+    // 그 외 4xx는 묶어서 client 에러로 처리
+    if (typeof status === 'number' && status >= 400 && status < 500) {
+      return {
+        type: 'client',
+        status,
+        code: serverCode,
+        message:
+          byCodeMsg ?? opts?.typeMessages?.client ?? (serverMsg || '요청을 처리할 수 없습니다.'),
+        raw: e,
+      };
+    }
+
+    // status가 없거나 분류되지 않은 Axios 에러
+    if (err.code === 'ECONNABORTED') {
+      return { type: 'network', code: err.code, message: '요청이 시간 초과되었습니다.', raw: e };
+    }
+    if ((err as any).code === 'ERR_CANCELED') {
+      return { type: 'cancelled', message: '요청이 취소되었습니다.', raw: e };
+    }
+
+    return {
+      type: 'unknown',
+      status,
+      code: serverCode,
+      message: byCodeMsg ?? serverMsg ?? '요청을 처리할 수 없습니다.',
+      raw: e,
+    };
+  }
+
+  // Axios 외 일반 오류
+  return { type: 'unknown', message: '알 수 없는 오류가 발생했습니다.', raw: e };
+}
+
+export function useApiError(options: UseApiErrorOptions = {}) {
+  const handleError = (e: unknown): AppError => {
+    const appError = normalizeAxiosError(e, options);
+    if (options.onAnyError) {
+      try {
+        options.onAnyError(appError);
+      } catch {}
+    }
+    // 여기서는 UI 출력을 하지 않고 각 호출부에서 처리하도록 함
+    return appError;
+  };
+
+  return { handleError };
+}

--- a/src/pages/login/hooks/useLoginForm.ts
+++ b/src/pages/login/hooks/useLoginForm.ts
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema, type LoginFormInputs } from '@/pages/login/utils/loginValidation';
 import axiosInstance from '@/api/axiosInstance';
-import { STORAGE_KEYS } from '@/utils/storageKeys';
 import { useAuth } from '@/hooks/useAuth';
 import { ENDPOINTS } from '@/api/endpoints';
 
@@ -28,20 +27,12 @@ export const useLoginForm = () => {
 
       const accessToken = res.data?.accessToken as string | undefined;
       const refreshToken = res.data?.refreshToken as string | undefined;
-      let user = res.data?.user as any | undefined;
 
       if (!accessToken || !refreshToken) {
         throw new Error('로그인 응답에 토큰이 없습니다.');
       }
-
-      if (!user) {
-        localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, accessToken);
-        localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
-        const me = await axiosInstance.get(ENDPOINTS.members.me);
-        user = me.data;
-      }
-
-      login({ accessToken, refreshToken, user });
+      login({ accessToken, refreshToken }); // user 정보 없이 토큰만으로 세션 유지
+      alert('로그인에 성공했습니다!');
       navigate('/');
     } catch (e) {
       console.error(e); // 이후 에러핸들링 로직 추가 예정

--- a/src/pages/login/hooks/useLoginForm.ts
+++ b/src/pages/login/hooks/useLoginForm.ts
@@ -1,5 +1,5 @@
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { usePageRouting } from '@/hooks/usePageRouting';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema, type LoginFormInputs } from '@/pages/login/utils/loginValidation';
 import axiosInstance from '@/api/axiosInstance';
@@ -7,7 +7,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { ENDPOINTS } from '@/api/endpoints';
 
 export const useLoginForm = () => {
-  const navigate = useNavigate();
+  const routing = usePageRouting();
   const { login } = useAuth();
   const {
     register,
@@ -33,14 +33,14 @@ export const useLoginForm = () => {
       }
       login({ accessToken, refreshToken }); // user 정보 없이 토큰만으로 세션 유지
       alert('로그인에 성공했습니다!');
-      navigate('/');
+      routing.home();
     } catch (e) {
       console.error(e); // 이후 에러핸들링 로직 추가 예정
     }
   };
 
   const navigateToRegister = () => {
-    navigate('/register');
+    routing.register();
   };
 
   return {

--- a/src/pages/login/hooks/useLoginForm.ts
+++ b/src/pages/login/hooks/useLoginForm.ts
@@ -2,9 +2,14 @@ import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema, type LoginFormInputs } from '@/pages/login/utils/loginValidation';
+import axiosInstance from '@/api/axiosInstance';
+import { STORAGE_KEYS } from '@/utils/storageKeys';
+import { useAuth } from '@/hooks/useAuth';
+import { ENDPOINTS } from '@/api/endpoints';
 
 export const useLoginForm = () => {
   const navigate = useNavigate();
+  const { login } = useAuth();
   const {
     register,
     handleSubmit,
@@ -14,10 +19,34 @@ export const useLoginForm = () => {
     mode: 'onChange',
   });
 
-  const onSubmit = (data: LoginFormInputs) => {
-    console.log(data);
-    // todo : 로그인 API 호출
-    navigate('/');
+  const onSubmit = async (data: LoginFormInputs) => {
+    try {
+      const res = await axiosInstance.post(ENDPOINTS.members.login, {
+        email: data.email,
+        password: data.password,
+      });
+
+      const accessToken = res.data?.accessToken as string | undefined;
+      const refreshToken = res.data?.refreshToken as string | undefined;
+      let user = res.data?.user as any | undefined;
+
+      if (!accessToken || !refreshToken) {
+        throw new Error('로그인 응답에 토큰이 없습니다.');
+      }
+
+      if (!user) {
+        // 로그인 POST 응답에 user 정보가 있다면 이 부분은 삭제
+        localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, accessToken);
+        localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
+        const me = await axiosInstance.get(ENDPOINTS.members.me);
+        user = me.data;
+      }
+
+      login({ accessToken, refreshToken, user });
+      navigate('/');
+    } catch (e) {
+      console.error(e); // 이후 에러핸들링 로직 추가 예정
+    }
   };
 
   const navigateToRegister = () => {

--- a/src/pages/login/hooks/useLoginForm.ts
+++ b/src/pages/login/hooks/useLoginForm.ts
@@ -35,7 +35,6 @@ export const useLoginForm = () => {
       }
 
       if (!user) {
-        // 로그인 POST 응답에 user 정보가 있다면 이 부분은 삭제
         localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, accessToken);
         localStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, refreshToken);
         const me = await axiosInstance.get(ENDPOINTS.members.me);

--- a/src/pages/register/hooks/useRegisterForm.ts
+++ b/src/pages/register/hooks/useRegisterForm.ts
@@ -1,13 +1,13 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { registerSchema, type RegisterFormInputs } from '@/pages/register/utils/registerValidation';
-import { useNavigate } from 'react-router-dom';
+import { usePageRouting } from '@/hooks/usePageRouting';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
 import { useAuth } from '@/hooks/useAuth';
 
 export const useRegisterForm = () => {
-  const navigate = useNavigate();
+  const routing = usePageRouting();
   const { login } = useAuth();
 
   const {
@@ -38,10 +38,10 @@ export const useRegisterForm = () => {
         // 회원가입 후 자동 로그인 처리 (user 정보는 사용하지 않음)
         login({ accessToken, refreshToken });
         alert('회원가입이 완료되어 자동으로 로그인되었습니다.');
-        navigate('/');
+        routing.home();
       } else {
         alert('회원가입이 완료되었습니다. 로그인해 주세요.');
-        navigate('/login');
+        routing.login();
       }
     } catch (e) {
       console.error(e); //이후 에러핸들링 로직 추가 예정

--- a/src/pages/register/hooks/useRegisterForm.ts
+++ b/src/pages/register/hooks/useRegisterForm.ts
@@ -4,9 +4,11 @@ import { registerSchema, type RegisterFormInputs } from '@/pages/register/utils/
 import { useNavigate } from 'react-router-dom';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
+import { useAuth } from '@/hooks/useAuth';
 
 export const useRegisterForm = () => {
   const navigate = useNavigate();
+  const { login } = useAuth();
 
   const {
     register,
@@ -19,8 +21,7 @@ export const useRegisterForm = () => {
 
   const onSubmit = async (data: RegisterFormInputs) => {
     try {
-      // 서버 스펙: { name, contact, email, password, mbti }
-      // confirmPassword 제외, phone -> contact로 매핑(하이픈 제거), mbti 빈 값이면 제외
+      // confirmPassword 제외, phone -> contact로 매핑, mbti 빈 값이면 제외
       const { confirmPassword, mbti, phone, ...rest } = data;
       const payload = {
         ...rest, // name, email, password
@@ -28,10 +29,20 @@ export const useRegisterForm = () => {
         ...(mbti ? { mbti } : {}),
       };
 
-      await axiosInstance.post(ENDPOINTS.members.signup, payload);
+      const res = await axiosInstance.post(ENDPOINTS.members.signup, payload);
 
-      alert('회원가입이 완료되었습니다!');
-      navigate('/login');
+      const accessToken = res.data?.accessToken as string | undefined;
+      const refreshToken = res.data?.refreshToken as string | undefined;
+
+      if (accessToken && refreshToken) {
+        // 회원가입 후 자동 로그인 처리 (user 정보는 사용하지 않음)
+        login({ accessToken, refreshToken });
+        alert('회원가입이 완료되어 자동으로 로그인되었습니다.');
+        navigate('/');
+      } else {
+        alert('회원가입이 완료되었습니다. 로그인해 주세요.');
+        navigate('/login');
+      }
     } catch (e) {
       console.error(e); //이후 에러핸들링 로직 추가 예정
     }

--- a/src/pages/register/hooks/useRegisterForm.ts
+++ b/src/pages/register/hooks/useRegisterForm.ts
@@ -2,6 +2,8 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { registerSchema, type RegisterFormInputs } from '@/pages/register/utils/registerValidation';
 import { useNavigate } from 'react-router-dom';
+import axiosInstance from '@/api/axiosInstance';
+import { ENDPOINTS } from '@/api/endpoints';
 
 export const useRegisterForm = () => {
   const navigate = useNavigate();
@@ -15,13 +17,19 @@ export const useRegisterForm = () => {
     mode: 'onChange',
   });
 
-  const onSubmit = (data: RegisterFormInputs) => {
-    // todo: 회원가입 API 호출
-    const { confirmPassword, ...submissionData } = data;
-    console.log('서버로 전송할 데이터:', submissionData);
+  const onSubmit = async (data: RegisterFormInputs) => {
+    try {
+      // confirmPassword 제외, mbti가 빈 값이면 제거
+      const { confirmPassword, mbti, ...rest } = data;
+      const payload = { ...rest, ...(mbti ? { mbti } : {}) };
 
-    alert('회원가입이 완료되었습니다!');
-    navigate('/login');
+      await axiosInstance.post(ENDPOINTS.members.signup, payload);
+
+      alert('회원가입이 완료되었습니다!');
+      navigate('/login');
+    } catch (e) {
+      console.error(e); //이후 에러핸들링 로직 추가 예정
+    }
   };
 
   return {

--- a/src/pages/register/hooks/useRegisterForm.ts
+++ b/src/pages/register/hooks/useRegisterForm.ts
@@ -19,9 +19,14 @@ export const useRegisterForm = () => {
 
   const onSubmit = async (data: RegisterFormInputs) => {
     try {
-      // confirmPassword 제외, mbti가 빈 값이면 제거
-      const { confirmPassword, mbti, ...rest } = data;
-      const payload = { ...rest, ...(mbti ? { mbti } : {}) };
+      // 서버 스펙: { name, contact, email, password, mbti }
+      // confirmPassword 제외, phone -> contact로 매핑(하이픈 제거), mbti 빈 값이면 제외
+      const { confirmPassword, mbti, phone, ...rest } = data;
+      const payload = {
+        ...rest, // name, email, password
+        contact: phone.replace(/-/g, ''),
+        ...(mbti ? { mbti } : {}),
+      };
 
       await axiosInstance.post(ENDPOINTS.members.signup, payload);
 

--- a/src/pages/register/hooks/useRegisterForm.ts
+++ b/src/pages/register/hooks/useRegisterForm.ts
@@ -24,7 +24,7 @@ export const useRegisterForm = () => {
       const { confirmPassword, mbti, phone, ...rest } = data;
       const payload = {
         ...rest, // name, email, password
-        contact: phone.replace(/-/g, ''),
+        contact: phone,
         ...(mbti ? { mbti } : {}),
       };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,14 +9,5 @@ export default defineConfig({
   /* Fix port */
   server: {
     port: 5173,
-    // CORS 문제 해결시 삭제 가능(프록시 설정)
-    proxy: {
-      '/api': {
-        target: 'http://18.118.161.98:8080',
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/api/, ''),
-      },
-    },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
-import react from "@vitejs/plugin-react";
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -9,5 +9,14 @@ export default defineConfig({
   /* Fix port */
   server: {
     port: 5173,
+    // CORS 문제 해결시 삭제 가능(프록시 설정)
+    proxy: {
+      '/api': {
+        target: 'http://18.118.161.98:8080',
+        changeOrigin: true,
+        secure: false,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
   },
 });


### PR DESCRIPTION
# 로그인/회원가입 API 요청 기능 구현

## 설명

- 로그인/회원가입 페이지에서 구현되지 않았던 POST API요청 기능을 구현했습니다

- **상세 설명**

- 백엔드 공통 엔드포인트를 환경변수를 통해 주입받아 사용하도록 했습니다. (.env.local)
- axiosInstance를 이용하여 API요청합니다.
- 회원가입시에 넘기는 데이터필드가 백엔드 요구 필드와 맞지 않아 수정하여 회원가입 정상 작동 확인했습니다. 
- 401에러시에 refresh 요청하는 과정을 promise를 변수형으로 유지하지않고 새롭게 생성하여 구독하는 방식으로 변경했습니다. 

- **기타 정보**:
- src/api/endpoints.ts에 엔드포인트 상수화를 했습니다. https://github.com/kakao-tech-campus-3rd-step3/Team8_FE/discussions/53#discussion-8947728
- ~로그인은 관련 이슈가 있어 해결해야할듯 합니다.~ 해결완료
- 중간에 프록시 설정 커밋이 있었는데 그 뒤에 다시 프록시 설정을 삭제했습니다. 주석처리하고싶었으나 충돌방지를 위해 원상태로 돌려놨습니다.
- 에러핸들링은 지금은 최소한의 부분만 해놨고 다음 주차에 표준에러핸들링 로직과 각 페이지에 맞는 세부 에러핸들링을 구현할 예정입니다.

## 관련 이슈(없다면 지워주세요)
- ~회원가입에 성공한 계정으로 로그인 진행 시 400(bad request) 에러가 발생합니다. ~ 해결완료
<!--- 바로 아래에 이슈 링크를 추가해 주세요.-->
https://github.com/kakao-tech-campus-3rd-step3/Team8_FE/issues/52#issue-3455810278 해결완료

