### PR TITLE
Stomp 웹 소켓 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 # For OS compatibility
 package-lock.json
+
+# Environment variables
+.env

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
+    "@stomp/stompjs": "^7.2.0",
     "@tanstack/react-query": "^5.87.1",
     "@xyflow/react": "^12.8.4",
     "axios": "^1.11.0",
@@ -25,6 +26,7 @@
     "react-router-dom": "^7.8.1",
     "react-time-picker": "^8.0.2",
     "react-toastify": "^11.0.5",
+    "sockjs-client": "^1.6.1",
     "styled-components": "^6.1.19",
     "zod": "^4.1.3"
   },
@@ -34,6 +36,7 @@
     "@types/react": "^19.1.10",
     "@types/react-datepicker": "^6.2.0",
     "@types/react-dom": "^19.1.7",
+    "@types/sockjs-client": "^1.5.4",
     "@types/styled-components": "^5.1.34",
     "@vitejs/plugin-react": "^5.0.0",
     "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-router-dom": "^7.8.1",
     "react-time-picker": "^8.0.2",
     "react-toastify": "^11.0.5",
-    "sockjs-client": "^1.6.1",
     "styled-components": "^6.1.19",
     "zod": "^4.1.3"
   },
@@ -36,7 +35,6 @@
     "@types/react": "^19.1.10",
     "@types/react-datepicker": "^6.2.0",
     "@types/react-dom": "^19.1.7",
-    "@types/sockjs-client": "^1.5.4",
     "@types/styled-components": "^5.1.34",
     "@vitejs/plugin-react": "^5.0.0",
     "eslint": "^9.33.0",

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,11 @@
+/*======================<React flow custom edge>/*======================*/
+.button-edge__label {
+  position: absolute;
+  pointer-events: all;
+  z-index: 10;
+}
+/*======================<React flow custom edge>/*======================*/
+
 /*======================<Pretendard Font>/*======================*/
 @import url('/fonts/pretendard/pretendardvariable.css');
 body {

--- a/src/index.css
+++ b/src/index.css
@@ -1,18 +1,18 @@
-/*======================<React flow custom edge>/*======================*/
+/*======================<React flow custom edge>======================*/
 .button-edge__label {
   position: absolute;
   pointer-events: all;
   z-index: 10;
 }
-/*======================<React flow custom edge>/*======================*/
+/*======================<React flow custom edge>======================*/
 
-/*======================<Pretendard Font>/*======================*/
+/*======================<Pretendard Font>======================*/
 @import url('/fonts/pretendard/pretendardvariable.css');
 body {
   font-family: 'Pretendard Variable', sans-serif;
   font-weight: 400;
 }
-/*======================<Pretendard Font>/*======================*/
+/*======================<Pretendard Font>======================*/
 
 /*! 
 https://serp.co/tools/css-reset/

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,3 @@
-/*======================<React flow custom edge>======================*/
-.button-edge__label {
-  position: absolute;
-  pointer-events: all;
-  z-index: 10;
-}
-/*======================<React flow custom edge>======================*/
-
 /*======================<Pretendard Font>======================*/
 @import url('/fonts/pretendard/pretendardvariable.css');
 body {
@@ -13,6 +5,14 @@ body {
   font-weight: 400;
 }
 /*======================<Pretendard Font>======================*/
+
+/*======================<React flow custom edge>======================*/
+.button-edge__label {
+  position: absolute;
+  pointer-events: all;
+  z-index: 10;
+}
+/*======================<React flow custom edge>======================*/
 
 /*! 
 https://serp.co/tools/css-reset/

--- a/src/pages/plan/PlanPage.tsx
+++ b/src/pages/plan/PlanPage.tsx
@@ -6,7 +6,7 @@ import ExportModal from './components/ExportModal';
 import { useEffect, useState } from 'react';
 import { colorSystem } from '@/styles/colorSystem';
 import Canvas from './flow/Canvas';
-import useSocketHandler from './hooks/useSocketHandler';
+import { SocketProvider } from './context/SocketContext';
 
 function PlanPage() {
   const id = useParams().id ?? '-1';
@@ -25,46 +25,8 @@ function PlanPage() {
     setIsExportModalOpen(false);
   };
 
-  const { client } = useSocketHandler({ planId: parseInt(id) });
-
   return (
-    <>
-      <>
-        <button
-          onClick={() => {
-            client.publish({
-              destination: `/app/plans/${id}/waypoints/init`,
-            });
-            console.log('초기 데이터 요청 완료');
-          }}
-        >
-          Publish init
-        </button>
-        <button
-          onClick={() => {
-            const newWaypoint = {
-              name: '새로운 경유지',
-              description: '경유지에 대한 설명입니다.',
-              address: '대구광역시 중구 동성로 1',
-              startTime: new Date().toISOString(),
-              endTime: new Date(Date.now() + 3600 * 1000).toISOString(),
-              locationCategory: 'FOOD',
-              locationSubCategory: 'CAFE',
-              xPosition: 0,
-              yPosition: 0,
-            };
-
-            client.publish({
-              destination: `/app/plans/${id}/waypoints/create`,
-              body: JSON.stringify(newWaypoint),
-            });
-
-            console.log('Create 요청 메시지 발행 완료:', newWaypoint);
-          }}
-        >
-          Publish Create
-        </button>
-      </>
+    <SocketProvider planId={parseInt(id)}>
       <InvitationPanel />
       <TitleBar>
         <Title>일본여행</Title>
@@ -73,7 +35,7 @@ function PlanPage() {
       </TitleBar>
       {isExportModalOpen && <ExportModal onClose={handleCloseModal} />}
       <Canvas />
-    </>
+    </SocketProvider>
   );
 }
 

--- a/src/pages/plan/PlanPage.tsx
+++ b/src/pages/plan/PlanPage.tsx
@@ -6,6 +6,7 @@ import ExportModal from './components/ExportModal';
 import { useEffect, useState } from 'react';
 import { colorSystem } from '@/styles/colorSystem';
 import Canvas from './flow/Canvas';
+import useSocketHandler from './hooks/useSocketHandler';
 
 function PlanPage() {
   const id = useParams().id ?? '-1';
@@ -24,8 +25,46 @@ function PlanPage() {
     setIsExportModalOpen(false);
   };
 
+  const { client } = useSocketHandler({ planId: parseInt(id) });
+
   return (
     <>
+      <>
+        <button
+          onClick={() => {
+            client.publish({
+              destination: `/app/plans/${id}/waypoints/init`,
+            });
+            console.log('초기 데이터 요청 완료');
+          }}
+        >
+          Publish init
+        </button>
+        <button
+          onClick={() => {
+            const newWaypoint = {
+              name: '새로운 경유지',
+              description: '경유지에 대한 설명입니다.',
+              address: '대구광역시 중구 동성로 1',
+              startTime: new Date().toISOString(),
+              endTime: new Date(Date.now() + 3600 * 1000).toISOString(),
+              locationCategory: 'FOOD',
+              locationSubCategory: 'CAFE',
+              xPosition: 0,
+              yPosition: 0,
+            };
+
+            client.publish({
+              destination: `/app/plans/${id}/waypoints/create`,
+              body: JSON.stringify(newWaypoint),
+            });
+
+            console.log('Create 요청 메시지 발행 완료:', newWaypoint);
+          }}
+        >
+          Publish Create
+        </button>
+      </>
       <InvitationPanel />
       <TitleBar>
         <Title>일본여행</Title>

--- a/src/pages/plan/components/ControlBar.tsx
+++ b/src/pages/plan/components/ControlBar.tsx
@@ -4,11 +4,24 @@ import NoteAlt from '@/assets/icons/NoteAlt';
 import { useSocket } from '../context/SocketContext';
 import StompURL from '../utils/StompURL';
 import type { MemoData } from '../flow/canvasComponents/Memo';
+import { useViewport } from '@xyflow/react';
 
 function ControlBar() {
   const { client, planId } = useSocket();
+  const { x, y, zoom } = useViewport();
+
+  const getCenter = () => {
+    const screenCenter = {
+      x: window.innerWidth / 2,
+      y: window.innerHeight / 2,
+    };
+    const canvasX = (screenCenter.x - x) / zoom;
+    const canvasY = (screenCenter.y - y) / zoom;
+    return { x: canvasX, y: canvasY };
+  };
 
   const createNewWaypoint = () => {
+    const { x, y } = getCenter();
     const newWaypoint = {
       name: '새 위치',
       description: '설명',
@@ -17,8 +30,8 @@ function ControlBar() {
       endTime: new Date(Date.now() + 3600 * 1000).toISOString(),
       locationCategory: 'DEFAULT',
       locationSubCategory: 'DEFAULT',
-      xPosition: 0,
-      yPosition: 0,
+      xPosition: x,
+      yPosition: y,
     };
 
     client.publish({
@@ -28,11 +41,12 @@ function ControlBar() {
   };
 
   const createNewMemo = () => {
+    const { x, y } = getCenter();
     const newMemo: MemoData = {
       title: '새 메모',
       content: '내용',
-      xPosition: 0,
-      yPosition: 0,
+      xPosition: x,
+      yPosition: y,
     };
 
     client.publish({
@@ -64,6 +78,7 @@ const ControlBarWrapper = styled.div`
   padding: 10px 20px;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 4;
 `;
 
 const NewNodeButton = styled.button`

--- a/src/pages/plan/components/ControlBar.tsx
+++ b/src/pages/plan/components/ControlBar.tsx
@@ -1,18 +1,52 @@
 import { styled } from 'styled-components';
 import FlagCircle from '@/assets/icons/FlagCircle';
 import NoteAlt from '@/assets/icons/NoteAlt';
+import { useSocket } from '../context/SocketContext';
+import StompURL from '../utils/StompURL';
+import type { MemoData } from '../flow/canvasComponents/Memo';
 
-type ControlBarPropsType = {
-  addNode: (type: 'waypoint' | 'memo') => void;
-};
+function ControlBar() {
+  const { client, planId } = useSocket();
 
-function ControlBar({ addNode }: ControlBarPropsType) {
+  const createNewWaypoint = () => {
+    const newWaypoint = {
+      name: '새 위치',
+      description: '설명',
+      address: '주소',
+      startTime: new Date().toISOString(),
+      endTime: new Date(Date.now() + 3600 * 1000).toISOString(),
+      locationCategory: 'DEFAULT',
+      locationSubCategory: 'DEFAULT',
+      xPosition: 0,
+      yPosition: 0,
+    };
+
+    client.publish({
+      destination: StompURL.PUB.WAYPOINT.CREATE(planId),
+      body: JSON.stringify(newWaypoint),
+    });
+  };
+
+  const createNewMemo = () => {
+    const newMemo: MemoData = {
+      title: '새 메모',
+      content: '내용',
+      xPosition: 0,
+      yPosition: 0,
+    };
+
+    client.publish({
+      destination: StompURL.PUB.MEMO.CREATE(planId),
+      body: JSON.stringify(newMemo),
+    });
+  };
+
   return (
     <ControlBarWrapper>
-      <NewNodeButton onClick={() => addNode('waypoint')}>
+      <NewNodeButton onClick={createNewWaypoint}>
         <FlagCircle />
       </NewNodeButton>
-      <NewNodeButton onClick={() => addNode('memo')}>
+      <NewNodeButton onClick={createNewMemo}>
         <NoteAlt />
       </NewNodeButton>
     </ControlBarWrapper>

--- a/src/pages/plan/context/SocketContext.tsx
+++ b/src/pages/plan/context/SocketContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+import useSocketHandler from '../hooks/useSocketHandler';
+
+type SocketContextValue = {
+  client: ReturnType<typeof useSocketHandler>['client'];
+  planId: number;
+};
+
+export const SocketContext = createContext<SocketContextValue | null>(null);
+
+export const useSocket = () => {
+  const context = useContext(SocketContext);
+  if (!context) throw new Error('useSocket must be used within a SocketProvider');
+  return context;
+};
+
+export const SocketProvider = ({ planId, children }: { planId: number; children: ReactNode }) => {
+  const { client } = useSocketHandler({ planId });
+
+  return (
+    <SocketContext.Provider value={{ client, planId }}>
+      {client ? children : <>실시간 연결을 생성중입니다...</>}
+    </SocketContext.Provider>
+  );
+};

--- a/src/pages/plan/flow/Canvas.tsx
+++ b/src/pages/plan/flow/Canvas.tsx
@@ -7,6 +7,7 @@ import { colorSystem } from '@/styles/colorSystem';
 import ControlBar from '../components/ControlBar';
 import { useCanvas } from '../hooks/useCanvas';
 import styled from 'styled-components';
+import { edgeTypes } from './edgeTypes';
 // const initialNodes = [{ id: '1', type: 'waypoint', position: { x: 0, y: 0 }, data: { value: '123' } }, { id: '2', type: 'memo', position: { x: 0, y: 0 }, data: { value: '123' } }];
 
 function Canvas() {
@@ -21,6 +22,7 @@ function Canvas() {
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
           onConnect={onConnect}
           /* 편집 이벤트는 canEdit일 때만 허용, 편집 제한 정책이 바뀌면 prop수정 필요 */
           onNodesChange={canEdit ? onNodesChange : undefined}

--- a/src/pages/plan/flow/Canvas.tsx
+++ b/src/pages/plan/flow/Canvas.tsx
@@ -40,10 +40,9 @@ function Canvas() {
         >
           <Background />
           <Controls />
+          <ControlBar />
         </ReactFlow>
       </EditGuard>
-
-      <ControlBar />
     </CanvasWrapper>
   );
 }

--- a/src/pages/plan/flow/Canvas.tsx
+++ b/src/pages/plan/flow/Canvas.tsx
@@ -13,7 +13,7 @@ import { edgeTypes } from './edgeTypes';
 function Canvas() {
   const canEdit = !isMobile;
 
-  const { nodes, onNodesChange, edges, onEdgesChange, onConnect, addNode } = useCanvas();
+  const { nodes, onNodesChange, edges, onEdgesChange, onConnect } = useCanvas();
 
   return (
     <CanvasWrapper>
@@ -42,7 +42,7 @@ function Canvas() {
         </ReactFlow>
       </EditGuard>
 
-      <ControlBar addNode={addNode} />
+      <ControlBar />
     </CanvasWrapper>
   );
 }

--- a/src/pages/plan/flow/Canvas.tsx
+++ b/src/pages/plan/flow/Canvas.tsx
@@ -13,7 +13,7 @@ import { edgeTypes } from './edgeTypes';
 function Canvas() {
   const canEdit = !isMobile;
 
-  const { nodes, onNodesChange, edges, onEdgesChange, onConnect } = useCanvas();
+  const { nodes, onNodesChange, edges, onEdgesChange, onConnect, onNodeDragStop } = useCanvas();
 
   return (
     <CanvasWrapper>
@@ -29,6 +29,7 @@ function Canvas() {
           onEdgesChange={canEdit ? onEdgesChange : undefined}
           nodesDraggable={canEdit}
           nodesConnectable={canEdit}
+          onNodeDragStop={onNodeDragStop}
           elementsSelectable={canEdit}
           style={{ backgroundColor: '#B8CEFF', width: '100%', height: '100%' }}
           fitView

--- a/src/pages/plan/flow/Canvas.tsx
+++ b/src/pages/plan/flow/Canvas.tsx
@@ -46,7 +46,7 @@ function Canvas() {
 }
 
 const CanvasWrapper = styled.div`
-  height: 100vh;
+  height: calc(100vh - 98px);
   width: 100%;
 `;
 

--- a/src/pages/plan/flow/canvasComponents/Arrow.ts
+++ b/src/pages/plan/flow/canvasComponents/Arrow.ts
@@ -1,7 +1,6 @@
 import type { TransportationCategory } from '../../utils/Category';
 
-export interface ArrowData {
-  memoId: number;
+export interface ArrowData extends Record<string, unknown> {
   startId: number;
   endId: number;
   transportationCategory: TransportationCategory;

--- a/src/pages/plan/flow/canvasComponents/Memo.ts
+++ b/src/pages/plan/flow/canvasComponents/Memo.ts
@@ -1,4 +1,5 @@
 export interface MemoData extends Record<string, unknown> {
+  id: number;
   title: string;
   content: string;
   xPosition: number;

--- a/src/pages/plan/flow/canvasComponents/Memo.ts
+++ b/src/pages/plan/flow/canvasComponents/Memo.ts
@@ -1,6 +1,6 @@
 export interface MemoData extends Record<string, unknown> {
   title: string;
-  text: string;
-  Xposition: number;
-  Yposition: number;
+  content: string;
+  xPosition: number;
+  yPosition: number;
 }

--- a/src/pages/plan/flow/canvasComponents/Waypoint.ts
+++ b/src/pages/plan/flow/canvasComponents/Waypoint.ts
@@ -2,7 +2,7 @@ import type { LocationCategory } from '../../utils/Category';
 
 export interface WaypointData extends Record<string, unknown> {
   id: number;
-  title: string;
+  name: string;
   description: string;
   address: string;
   startTime: Date;

--- a/src/pages/plan/flow/edgeTypes.ts
+++ b/src/pages/plan/flow/edgeTypes.ts
@@ -1,0 +1,3 @@
+import RouteEdge from './edges/RouteEdge';
+
+export const edgeTypes = { route: RouteEdge };

--- a/src/pages/plan/flow/edges/RouteEdge.tsx
+++ b/src/pages/plan/flow/edges/RouteEdge.tsx
@@ -1,0 +1,51 @@
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getBezierPath,
+  useReactFlow,
+  type EdgeProps,
+} from '@xyflow/react';
+
+export default function RouteEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style = {},
+  markerEnd,
+}: EdgeProps) {
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const { setEdges } = useReactFlow();
+  const onEdgeClick = () => {
+    setEdges((edges) => edges.filter((edge) => edge.id !== id));
+  };
+
+  return (
+    <>
+      <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
+      <EdgeLabelRenderer>
+        <div
+          className="button-edge__label nodrag nopan"
+          style={{
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+          }}
+        >
+          <button className="button-edge__button" onClick={onEdgeClick}>
+            ×
+          </button>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+}

--- a/src/pages/plan/flow/edges/RouteEdge.tsx
+++ b/src/pages/plan/flow/edges/RouteEdge.tsx
@@ -7,11 +7,7 @@ import {
 } from '@xyflow/react';
 import { useState } from 'react';
 import styled from 'styled-components';
-import {
-  TransportationCategory,
-  TransportationCategoryMeta,
-  type TransportationCategory as CategoryType,
-} from '../../utils/Category';
+import { TransportationCategoryInfo, type TransportationCategory } from '../../utils/Category';
 import type { ArrowData } from '../canvasComponents/Arrow';
 import type { RouteEdgeType } from '../../hooks/useCanvas';
 
@@ -46,10 +42,10 @@ export default function RouteEdge({
     title: data?.title ?? '새 경로',
     description: data?.description ?? '',
     duration: data?.duration ?? 0,
-    transportationCategory: data?.transportationCategory ?? TransportationCategory.DEFAULT,
+    transportationCategory: data?.transportationCategory ?? 'DEFAULT',
   };
 
-  const vehicleMeta = TransportationCategoryMeta[mergedData.transportationCategory];
+  const vehicleMeta = TransportationCategoryInfo[mergedData.transportationCategory];
   const mergedStyle = {
     ...style,
     stroke: vehicleMeta.color,
@@ -115,12 +111,12 @@ export default function RouteEdge({
                 <select
                   value={mergedData.transportationCategory}
                   onChange={(e) =>
-                    onUpdateData('transportationCategory', e.target.value as CategoryType)
+                    onUpdateData('transportationCategory', e.target.value as TransportationCategory)
                   }
                 >
-                  {Object.values(TransportationCategory).map((v) => (
-                    <option key={v} value={v}>
-                      {TransportationCategoryMeta[v].icon} {v}
+                  {Object.entries(TransportationCategoryInfo).map(([key, info]) => (
+                    <option key={key} value={key}>
+                      {info.icon} {key}
                     </option>
                   ))}
                 </select>

--- a/src/pages/plan/flow/edges/RouteEdge.tsx
+++ b/src/pages/plan/flow/edges/RouteEdge.tsx
@@ -5,6 +5,15 @@ import {
   useReactFlow,
   type EdgeProps,
 } from '@xyflow/react';
+import { useState } from 'react';
+import styled from 'styled-components';
+import {
+  TransportationCategory,
+  TransportationCategoryMeta,
+  type TransportationCategory as CategoryType,
+} from '../../utils/Category';
+import type { ArrowData } from '../canvasComponents/Arrow';
+import type { RouteEdgeType } from '../../hooks/useCanvas';
 
 export default function RouteEdge({
   id,
@@ -16,7 +25,8 @@ export default function RouteEdge({
   targetPosition,
   style = {},
   markerEnd,
-}: EdgeProps) {
+  data,
+}: EdgeProps<RouteEdgeType>) {
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
     sourceY,
@@ -27,25 +37,190 @@ export default function RouteEdge({
   });
 
   const { setEdges } = useReactFlow();
-  const onEdgeClick = () => {
+  const [open, setOpen] = useState(false);
+
+  // 기본 데이터 안전 처리
+  const mergedData: ArrowData = {
+    startId: data?.startId ?? -1,
+    endId: data?.endId ?? -1,
+    title: data?.title ?? '새 경로',
+    description: data?.description ?? '',
+    duration: data?.duration ?? 0,
+    transportationCategory: data?.transportationCategory ?? TransportationCategory.DEFAULT,
+  };
+
+  const vehicleMeta = TransportationCategoryMeta[mergedData.transportationCategory];
+  const mergedStyle = {
+    ...style,
+    stroke: vehicleMeta.color,
+    strokeWidth: 4,
+  };
+
+  const onDelete = () => {
     setEdges((edges) => edges.filter((edge) => edge.id !== id));
+  };
+
+  const onUpdateData = <K extends keyof ArrowData>(key: K, value: ArrowData[K]) => {
+    setEdges((edges) =>
+      edges.map((edge) =>
+        edge.id === id ? { ...edge, data: { ...edge.data, [key]: value } } : edge
+      )
+    );
   };
 
   return (
     <>
-      <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
+      <BaseEdge path={edgePath} markerEnd={markerEnd} style={mergedStyle} />
       <EdgeLabelRenderer>
-        <div
-          className="button-edge__label nodrag nopan"
+        <LabelWrapper
+          className="nodrag nopan"
           style={{
             transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
           }}
         >
-          <button className="button-edge__button" onClick={onEdgeClick}>
-            ×
-          </button>
-        </div>
+          {!open ? (
+            <EditButton color={vehicleMeta.color} onClick={() => setOpen(true)}>
+              {vehicleMeta.icon}
+            </EditButton>
+          ) : (
+            <FormContainer>
+              <FormRow>
+                <label>제목</label>
+                <input
+                  type="text"
+                  value={mergedData.title}
+                  onChange={(e) => onUpdateData('title', e.target.value)}
+                />
+              </FormRow>
+              <FormRow>
+                <label>설명</label>
+                <input
+                  type="text"
+                  value={mergedData.description}
+                  onChange={(e) => onUpdateData('description', e.target.value)}
+                />
+              </FormRow>
+              <FormRow>
+                <label>소요시간(분)</label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={mergedData.duration}
+                  onChange={(e) => onUpdateData('duration', parseFloat(e.target.value) || 0)}
+                />
+              </FormRow>
+              <FormRow>
+                <label>이동수단</label>
+                <select
+                  value={mergedData.transportationCategory}
+                  onChange={(e) =>
+                    onUpdateData('transportationCategory', e.target.value as CategoryType)
+                  }
+                >
+                  {Object.values(TransportationCategory).map((v) => (
+                    <option key={v} value={v}>
+                      {TransportationCategoryMeta[v].icon} {v}
+                    </option>
+                  ))}
+                </select>
+              </FormRow>
+              <FormActions>
+                <ActionButton onClick={() => setOpen(false)}>닫기</ActionButton>
+                <DeleteButton onClick={onDelete}>삭제</DeleteButton>
+              </FormActions>
+            </FormContainer>
+          )}
+        </LabelWrapper>
       </EdgeLabelRenderer>
     </>
   );
 }
+
+//
+// ---------------------- styled-components ----------------------
+//
+
+const LabelWrapper = styled.div`
+  position: absolute;
+  z-index: 10;
+  pointer-events: all;
+`;
+
+const EditButton = styled.button<{ color: string }>`
+  background: #fff;
+  border: 2px solid ${({ color }) => color};
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  font-size: 15px;
+  transition: background 0.2s ease, transform 0.1s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  &:hover {
+    background: ${({ color }) => color}22;
+    transform: scale(1.1);
+  }
+`;
+
+const FormContainer = styled.div`
+  background: #ffffff;
+  border: 1px solid #aaa;
+  border-radius: 8px;
+  padding: 10px;
+  min-width: 230px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+`;
+
+const FormRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 8px;
+
+  label {
+    font-size: 12px;
+    color: #444;
+  }
+
+  input,
+  select {
+    font-size: 12px;
+    padding: 4px 6px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    outline: none;
+    &:focus {
+      border-color: #5c7cfa;
+    }
+  }
+`;
+
+const FormActions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+`;
+
+const ActionButton = styled.button`
+  background: #e9ecef;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 12px;
+  &:hover {
+    background: #dfe3e6;
+  }
+`;
+
+const DeleteButton = styled(ActionButton)`
+  background: #ffefef;
+  border: 1px solid #ff9999;
+  color: #d60000;
+  &:hover {
+    background: #ffd7d7;
+  }
+`;

--- a/src/pages/plan/flow/nodes/MemoNode.tsx
+++ b/src/pages/plan/flow/nodes/MemoNode.tsx
@@ -1,14 +1,29 @@
 import { colorSystem } from '@/styles/colorSystem';
 import { fontSystem } from '@/styles/fontSystem';
 import styled from 'styled-components';
+import { useDataSyncMemo } from '../../hooks/useDataSyncMemo';
+import type { MemoData } from '../canvasComponents/Memo';
 
 // props로 data 받아올 수 있습니다.
-function MemoNode() {
+function MemoNode({ id, data }: { id: string; data: MemoData }) {
+  const { handleLocalDataChange } = useDataSyncMemo({ id, data });
+
   return (
     <MemoNodeContainer>
-      <MemoTitle type="text" className="nodrag" />
+      <MemoTitle
+        type="text"
+        className="nodrag"
+        onChange={(e) => {
+          handleLocalDataChange('title', e.target.value);
+        }}
+      />
       <ContentDivider />
-      <MemoArea className="nodrag" />
+      <MemoArea
+        className="nodrag"
+        onChange={(e) => {
+          handleLocalDataChange('content', e.target.value);
+        }}
+      />
     </MemoNodeContainer>
   );
 }

--- a/src/pages/plan/flow/nodes/MemoNode.tsx
+++ b/src/pages/plan/flow/nodes/MemoNode.tsx
@@ -13,6 +13,7 @@ function MemoNode({ id, data }: { id: string; data: MemoData }) {
       <MemoTitle
         type="text"
         className="nodrag"
+        value={data.title}
         onChange={(e) => {
           handleLocalDataChange('title', e.target.value);
         }}
@@ -20,6 +21,7 @@ function MemoNode({ id, data }: { id: string; data: MemoData }) {
       <ContentDivider />
       <MemoArea
         className="nodrag"
+        value={data.content}
         onChange={(e) => {
           handleLocalDataChange('content', e.target.value);
         }}

--- a/src/pages/plan/flow/nodes/WaypointNode.tsx
+++ b/src/pages/plan/flow/nodes/WaypointNode.tsx
@@ -4,11 +4,7 @@ import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import { colorSystem } from '@/styles/colorSystem';
 import { fontSystem } from '@/styles/fontSystem';
-import {
-  LocationType,
-  type LocationCategory,
-  LocationCategoryMeta,
-} from '@/pages/plan/utils/Category';
+import { type LocationCategory, LocationCategoryMeta } from '@/pages/plan/utils/Category';
 import { CustomTimeInput } from './CustomTimeInput';
 import { type WaypointData } from '../canvasComponents/Waypoint';
 import { useAutosizeInput } from '../../hooks/useAutosizeInput';
@@ -50,7 +46,7 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
     setCategorySelectorOpen(false);
   };
 
-  const titleProps = useAutosizeInput(data.title);
+  const nameProps = useAutosizeInput(data.name);
   const addressProps = useAutosizeInput(data.description);
 
   return (
@@ -76,13 +72,13 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
         </IconWrapper>
         <VerticalLayout>
           {/* 6. UI 요소들이 data state를 사용하도록 바인딩 수정 */}
-          <Title
+          <Name
             as="input"
             type="text"
-            value={data.title}
-            onChange={(e) => handleDataChange('title', e.target.value)}
+            value={data.name}
+            onChange={(e) => handleDataChange('name', e.target.value)}
             className="nodrag"
-            {...titleProps}
+            {...nameProps}
           />
           <HorizontalLayout>
             <Address
@@ -203,7 +199,7 @@ const BaseInputStyles = `
   min-width: 50px;
 `;
 
-const Title = styled.div`
+const Name = styled.div`
   ${fontSystem.title.xlarge}
   ${BaseInputStyles}
 `;

--- a/src/pages/plan/flow/nodes/WaypointNode.tsx
+++ b/src/pages/plan/flow/nodes/WaypointNode.tsx
@@ -9,11 +9,14 @@ import { CustomTimeInput } from './CustomTimeInput';
 import { type WaypointData } from '../canvasComponents/Waypoint';
 import { useAutosizeInput } from '../../hooks/useAutosizeInput';
 import { Handle, Position, useReactFlow } from '@xyflow/react';
+import { useDataSyncWaypoint } from '../../hooks/useDataSyncWaypoint';
 
 function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
   const { setNodes } = useReactFlow();
   const [isCategorySelectorOpen, setCategorySelectorOpen] = useState(false);
   const iconWrapperRef = useRef<HTMLDivElement>(null);
+
+  useDataSyncWaypoint({ data });
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {

--- a/src/pages/plan/flow/nodes/WaypointNode.tsx
+++ b/src/pages/plan/flow/nodes/WaypointNode.tsx
@@ -12,22 +12,10 @@ import {
 import { CustomTimeInput } from './CustomTimeInput';
 import { type WaypointData } from '../canvasComponents/Waypoint';
 import { useAutosizeInput } from '../../hooks/useAutosizeInput';
-import { Handle, Position } from '@xyflow/react';
+import { Handle, Position, useReactFlow } from '@xyflow/react';
 
-// props로 data 받아올 수 있습니다.
-function WaypointNode() {
-  const [data, setData] = useState<WaypointData>({
-    id: 0,
-    title: '위치 제목',
-    description: '위치 설명',
-    address: '주소',
-    startTime: new Date(0, 0, 0, 0, 0),
-    endTime: new Date(0, 0, 0, 0, 0),
-    memoID: 0,
-    locationCategory: LocationType.DEFAULT.DEFAULT,
-    xPosition: 0,
-    yPosition: 0,
-  });
+function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
+  const { setNodes } = useReactFlow();
   const [isCategorySelectorOpen, setCategorySelectorOpen] = useState(false);
   const iconWrapperRef = useRef<HTMLDivElement>(null);
 
@@ -50,7 +38,11 @@ function WaypointNode() {
   }, [isCategorySelectorOpen]);
 
   const handleDataChange = (field: keyof WaypointData, value: any) => {
-    setData((prev) => ({ ...prev, [field]: value }));
+    setNodes((nds) =>
+      nds.map((node) =>
+        node.id === id ? { ...node, data: { ...node.data, [field]: value } } : node
+      )
+    );
   };
 
   const handleCategoryChange = (selectedCategory: string) => {

--- a/src/pages/plan/flow/nodes/WaypointNode.tsx
+++ b/src/pages/plan/flow/nodes/WaypointNode.tsx
@@ -16,10 +16,6 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
   const iconWrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    console.log(`웹 소켓 데이터 전송`, data);
-  }, [data]);
-
-  useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (iconWrapperRef.current && !iconWrapperRef.current.contains(event.target as Node)) {
         setCategorySelectorOpen(false);
@@ -91,7 +87,7 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
             />
             <TimeWrapper>
               <DatePicker
-                selected={data.startTime}
+                selected={new Date(data.startTime)}
                 onChange={(date: Date | null) => handleDataChange('startTime', date)}
                 showTimeSelect
                 showTimeSelectOnly
@@ -102,7 +98,7 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
               />
               ~
               <DatePicker
-                selected={data.endTime}
+                selected={new Date(data.endTime)}
                 onChange={(date: Date | null) => handleDataChange('endTime', date)}
                 showTimeSelect
                 showTimeSelectOnly

--- a/src/pages/plan/flow/nodes/WaypointNode.tsx
+++ b/src/pages/plan/flow/nodes/WaypointNode.tsx
@@ -8,15 +8,14 @@ import { type LocationCategory, LocationCategoryMeta } from '@/pages/plan/utils/
 import { CustomTimeInput } from './CustomTimeInput';
 import { type WaypointData } from '../canvasComponents/Waypoint';
 import { useAutosizeInput } from '../../hooks/useAutosizeInput';
-import { Handle, Position, useReactFlow } from '@xyflow/react';
+import { Handle, Position } from '@xyflow/react';
 import { useDataSyncWaypoint } from '../../hooks/useDataSyncWaypoint';
 
 function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
-  const { setNodes } = useReactFlow();
   const [isCategorySelectorOpen, setCategorySelectorOpen] = useState(false);
   const iconWrapperRef = useRef<HTMLDivElement>(null);
 
-  useDataSyncWaypoint({ data });
+  const { handleLocalDataChange } = useDataSyncWaypoint({ id, data });
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -32,16 +31,8 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
     };
   }, [isCategorySelectorOpen]);
 
-  const handleDataChange = (field: keyof WaypointData, value: any) => {
-    setNodes((nds) =>
-      nds.map((node) =>
-        node.id === id ? { ...node, data: { ...node.data, [field]: value } } : node
-      )
-    );
-  };
-
   const handleCategoryChange = (selectedCategory: string) => {
-    handleDataChange('locationCategory', selectedCategory);
+    handleLocalDataChange('locationCategory', selectedCategory);
     setCategorySelectorOpen(false);
   };
 
@@ -75,7 +66,7 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
             as="input"
             type="text"
             value={data.name}
-            onChange={(e) => handleDataChange('name', e.target.value)}
+            onChange={(e) => handleLocalDataChange('name', e.target.value)}
             className="nodrag"
             {...nameProps}
           />
@@ -84,14 +75,14 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
               as="input"
               type="text"
               value={data.address}
-              onChange={(e) => handleDataChange('address', e.target.value)}
+              onChange={(e) => handleLocalDataChange('address', e.target.value)}
               className="nodrag"
               {...addressProps}
             />
             <TimeWrapper>
               <DatePicker
                 selected={new Date(data.startTime)}
-                onChange={(date: Date | null) => handleDataChange('startTime', date)}
+                onChange={(date: Date | null) => handleLocalDataChange('startTime', date)}
                 showTimeSelect
                 showTimeSelectOnly
                 timeIntervals={1}
@@ -102,7 +93,7 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
               ~
               <DatePicker
                 selected={new Date(data.endTime)}
-                onChange={(date: Date | null) => handleDataChange('endTime', date)}
+                onChange={(date: Date | null) => handleLocalDataChange('endTime', date)}
                 showTimeSelect
                 showTimeSelectOnly
                 timeIntervals={1}
@@ -116,7 +107,7 @@ function WaypointNode({ id, data }: { id: string; data: WaypointData }) {
             placeholder="메모..."
             className="nodrag"
             value={data.description}
-            onChange={(e) => handleDataChange('description', e.target.value)}
+            onChange={(e) => handleLocalDataChange('description', e.target.value)}
           />
         </VerticalLayout>
       </HorizontalLayout>

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -147,7 +147,14 @@ export function useCanvas() {
         });
         break;
       case 'memo':
-        // TBD
+        client.publish({
+          destination: StompURL.PUB.MEMO.UPDATE(planId, node.data.id),
+          body: JSON.stringify({
+            ...node.data,
+            xPosition: node.position.x,
+            yPosition: node.position.y,
+          } as MemoData),
+        });
         break;
     }
   };

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import {
   addEdge,
   useEdgesState,
@@ -10,6 +10,9 @@ import {
 import type { WaypointData } from '../flow/canvasComponents/Waypoint';
 import type { MemoData } from '../flow/canvasComponents/Memo';
 import type { ArrowData } from '../flow/canvasComponents/Arrow';
+import { socketEventBus } from '../hooks/useSocketHandler';
+import type { WayPointCreateType } from '../types/WaypointResponseBodyType';
+import type { MemoCreateType } from '../types/MemoResponseBodyType';
 
 export type WaypointNodeType = Node<WaypointData, 'waypoint'>;
 export type MemoNodeType = Node<MemoData, 'memo'>;
@@ -56,7 +59,7 @@ export function useCanvas() {
             position: { x: Math.random() * 400, y: Math.random() * 400 },
             data: {
               id: 0,
-              title: '새 위치',
+              name: '새 위치',
               description: '설명',
               address: '주소',
               startTime: new Date(),
@@ -87,6 +90,54 @@ export function useCanvas() {
     },
     [setNodes]
   );
+
+  useEffect(() => {
+    function handleWaypointCreate(e: Event) {
+      const { detail } = e as CustomEvent<WayPointCreateType>;
+      const newWp = detail.waypoint;
+
+      setNodes((nds) => [
+        ...nds,
+        {
+          id: String(newWp.id),
+          type: 'waypoint',
+          position: { x: newWp.xPosition, y: newWp.yPosition },
+          data: {
+            ...newWp,
+          },
+        },
+      ]);
+    }
+
+    socketEventBus.addEventListener('WAYPOINT_CREATE', handleWaypointCreate);
+    return () => {
+      socketEventBus.removeEventListener('WAYPOINT_CREATE', handleWaypointCreate);
+    };
+  }, [setNodes]);
+
+  useEffect(() => {
+    function handleMemoCreate(e: Event) {
+      const { detail } = e as CustomEvent<MemoCreateType>;
+      const newMemo = detail.memo;
+
+      setNodes((nds) => [
+        ...nds,
+        {
+          id: String(newMemo.id),
+          type: 'memo',
+          position: { x: newMemo.xPosition, y: newMemo.yPosition },
+          data: {
+            ...newMemo,
+          },
+        },
+      ]);
+    }
+
+    socketEventBus.addEventListener('MEMO_CREATE', handleMemoCreate);
+    return () => {
+      socketEventBus.removeEventListener('MEMO_CREATE', handleMemoCreate);
+    };
+  }, [setNodes]);
 
   return {
     nodes,

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -13,6 +13,8 @@ import type { ArrowData } from '../flow/canvasComponents/Arrow';
 import { socketEventBus } from '../hooks/useSocketHandler';
 import type { WayPointCreateType, WayPointUpdateType } from '../types/WaypointResponseBodyType';
 import type { MemoCreateType } from '../types/MemoResponseBodyType';
+import { useSocket } from './useSocket';
+import StompURL from '../utils/StompURL';
 
 export type WaypointNodeType = Node<WaypointData, 'waypoint'>;
 export type MemoNodeType = Node<MemoData, 'memo'>;
@@ -175,6 +177,26 @@ export function useCanvas() {
     };
   }, [setNodes]);
 
+  const { planId, client } = useSocket();
+
+  const onNodeDragStop = (event: React.MouseEvent, node: CanvasNodes) => {
+    switch (node.type) {
+      case 'waypoint':
+        client.publish({
+          destination: StompURL.PUB.WAYPOINT.UPDATE(planId, node.data.id),
+          body: JSON.stringify({
+            ...node.data,
+            xPosition: node.position.x,
+            yPosition: node.position.y,
+          } as WaypointData),
+        });
+        break;
+      case 'memo':
+        // TBD
+        break;
+    }
+  };
+
   return {
     nodes,
     setNodes,
@@ -184,5 +206,6 @@ export function useCanvas() {
     onEdgesChange,
     onConnect,
     addNode,
+    onNodeDragStop,
   };
 }

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -9,17 +9,37 @@ import {
 } from '@xyflow/react';
 import type { WaypointData } from '../flow/canvasComponents/Waypoint';
 import type { MemoData } from '../flow/canvasComponents/Memo';
+import type { ArrowData } from '../flow/canvasComponents/Arrow';
 
-export type WaypointNode = Node<WaypointData, 'waypoint'>;
-export type MemoNode = Node<MemoData, 'memo'>;
-export type CanvasNode = WaypointNode | MemoNode;
+export type WaypointNodeType = Node<WaypointData, 'waypoint'>;
+export type MemoNodeType = Node<MemoData, 'memo'>;
+export type CanvasNodes = WaypointNodeType | MemoNodeType;
+export type RouteEdgeType = Edge<ArrowData, 'route'>;
+export type CanvasEdges = RouteEdgeType;
 
 export function useCanvas() {
-  const [nodes, setNodes, onNodesChange] = useNodesState<CanvasNode>([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+  const [nodes, setNodes, onNodesChange] = useNodesState<CanvasNodes>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<CanvasEdges>([]);
 
   const onConnect = useCallback(
-    (params: Edge | Connection) => setEdges((eds) => addEdge({ ...params, type: 'route' }, eds)),
+    (params: Connection) =>
+      setEdges((eds) =>
+        addEdge<RouteEdgeType>(
+          {
+            ...params,
+            type: 'route',
+            data: {
+              startId: -1,
+              endId: -1,
+              title: '새 경로',
+              description: '',
+              duration: 0,
+              transportationCategory: 'DEFAULT',
+            },
+          },
+          eds
+        )
+      ),
     [setEdges]
   );
 

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -119,7 +119,6 @@ export function useCanvas() {
     function handleMemoCreate(e: Event) {
       const { detail } = e as CustomEvent<MemoCreateType>;
       const newMemo = detail.memo;
-
       setNodes((nds) => [
         ...nds,
         {

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -48,51 +48,6 @@ export function useCanvas() {
     [setEdges]
   );
 
-  const addNode = useCallback(
-    (type: 'waypoint' | 'memo') => {
-      const id = crypto.randomUUID();
-
-      if (type === 'waypoint') {
-        setNodes((nds) => [
-          ...nds,
-          {
-            id,
-            type: 'waypoint',
-            position: { x: Math.random() * 400, y: Math.random() * 400 },
-            data: {
-              id: 0,
-              name: '새 위치',
-              description: '설명',
-              address: '주소',
-              startTime: new Date(),
-              endTime: new Date(),
-              memoID: 0,
-              locationCategory: 'DEFAULT',
-              xPosition: 0,
-              yPosition: 0,
-            },
-          },
-        ]);
-      } else {
-        setNodes((nds) => [
-          ...nds,
-          {
-            id,
-            type: 'memo',
-            position: { x: Math.random() * 400, y: Math.random() * 400 },
-            data: {
-              title: '새 메모',
-              content: '',
-              xPosition: 0,
-              yPosition: 0,
-            },
-          },
-        ]);
-      }
-    },
-    [setNodes]
-  );
-
   useEffect(() => {
     function handleWaypointCreate(e: Event) {
       const { detail } = e as CustomEvent<WayPointCreateType>;
@@ -205,7 +160,6 @@ export function useCanvas() {
     setEdges,
     onEdgesChange,
     onConnect,
-    addNode,
     onNodeDragStop,
   };
 }

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -57,8 +57,8 @@ export function useCanvas() {
             data: {
               id: 0,
               title: '새 위치',
-              description: '',
-              address: '',
+              description: '설명',
+              address: '주소',
               startTime: new Date(),
               endTime: new Date(),
               memoID: 0,

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -179,7 +179,7 @@ export function useCanvas() {
 
   const { planId, client } = useSocket();
 
-  const onNodeDragStop = (event: React.MouseEvent, node: CanvasNodes) => {
+  const onNodeDragStop = (_event: React.MouseEvent, node: CanvasNodes) => {
     switch (node.type) {
       case 'waypoint':
         client.publish({

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -77,9 +77,9 @@ export function useCanvas() {
             position: { x: Math.random() * 400, y: Math.random() * 400 },
             data: {
               title: '새 메모',
-              text: '',
-              Xposition: 0,
-              Yposition: 0,
+              content: '',
+              xPosition: 0,
+              yPosition: 0,
             },
           },
         ]);

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -94,7 +94,7 @@ export function useCanvas() {
   useEffect(() => {
     function handleWaypointCreate(e: Event) {
       const { detail } = e as CustomEvent<WayPointCreateType>;
-      const newWp = detail.waypoint;
+      const newWp = detail.WAYPOINT;
 
       setNodes((nds) => [
         ...nds,
@@ -118,7 +118,8 @@ export function useCanvas() {
   useEffect(() => {
     function handleMemoCreate(e: Event) {
       const { detail } = e as CustomEvent<MemoCreateType>;
-      const newMemo = detail.memo;
+      const newMemo = detail.MEMO;
+
       setNodes((nds) => [
         ...nds,
         {

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -99,7 +99,7 @@ export function useCanvas() {
       setNodes((nds) => [
         ...nds,
         {
-          id: String(newWp.id),
+          id: `waypoint:${newWp.id}`,
           type: 'waypoint',
           position: { x: newWp.xPosition, y: newWp.yPosition },
           data: {
@@ -122,7 +122,7 @@ export function useCanvas() {
       setNodes((nds) => [
         ...nds,
         {
-          id: String(newMemo.id),
+          id: `memo:${newMemo.id}`,
           type: 'memo',
           position: { x: newMemo.xPosition, y: newMemo.yPosition },
           data: {

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -12,7 +12,7 @@ import type { MemoData } from '../flow/canvasComponents/Memo';
 import type { ArrowData } from '../flow/canvasComponents/Arrow';
 import { socketEventBus } from '../hooks/useSocketHandler';
 import type { WayPointCreateType, WayPointUpdateType } from '../types/WaypointResponseBodyType';
-import type { MemoCreateType } from '../types/MemoResponseBodyType';
+import type { MemoCreateType, MemoUpdateType } from '../types/MemoResponseBodyType';
 import { useSocket } from './useSocket';
 import StompURL from '../utils/StompURL';
 
@@ -129,6 +129,42 @@ export function useCanvas() {
     socketEventBus.addEventListener('MEMO_CREATE', handleMemoCreate);
     return () => {
       socketEventBus.removeEventListener('MEMO_CREATE', handleMemoCreate);
+    };
+  }, [setNodes]);
+
+  useEffect(() => {
+    function handleMemoUpdate(e: Event) {
+      const { detail } = e as CustomEvent<MemoUpdateType>;
+      const newMemo = detail.MEMO;
+
+      setNodes((nds) => {
+        const nodeId = `memo:${newMemo.id}`;
+        const existingNode = nds.find((node) => node.id === nodeId);
+
+        if (!existingNode) {
+          console.error('정보를 동기화하는 과정에서 문제가 있었습니다.');
+        }
+
+        return nds.map((node) =>
+          node.id === nodeId
+            ? ({
+                ...node,
+                position: {
+                  x: newMemo.xPosition ?? node.position.x,
+                  y: newMemo.yPosition ?? node.position.y,
+                },
+                data: {
+                  ...newMemo,
+                },
+              } as MemoNodeType)
+            : node
+        );
+      });
+    }
+
+    socketEventBus.addEventListener('MEMO_UPDATE', handleMemoUpdate);
+    return () => {
+      socketEventBus.removeEventListener('MEMO_UPDATE', handleMemoUpdate);
     };
   }, [setNodes]);
 

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -19,7 +19,7 @@ export function useCanvas() {
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
 
   const onConnect = useCallback(
-    (params: Edge | Connection) => setEdges((eds) => addEdge(params, eds)),
+    (params: Edge | Connection) => setEdges((eds) => addEdge({ ...params, type: 'route' }, eds)),
     [setEdges]
   );
 

--- a/src/pages/plan/hooks/useCanvas.ts
+++ b/src/pages/plan/hooks/useCanvas.ts
@@ -11,7 +11,7 @@ import type { WaypointData } from '../flow/canvasComponents/Waypoint';
 import type { MemoData } from '../flow/canvasComponents/Memo';
 import type { ArrowData } from '../flow/canvasComponents/Arrow';
 import { socketEventBus } from '../hooks/useSocketHandler';
-import type { WayPointCreateType } from '../types/WaypointResponseBodyType';
+import type { WayPointCreateType, WayPointUpdateType } from '../types/WaypointResponseBodyType';
 import type { MemoCreateType } from '../types/MemoResponseBodyType';
 
 export type WaypointNodeType = Node<WaypointData, 'waypoint'>;
@@ -112,6 +112,42 @@ export function useCanvas() {
     socketEventBus.addEventListener('WAYPOINT_CREATE', handleWaypointCreate);
     return () => {
       socketEventBus.removeEventListener('WAYPOINT_CREATE', handleWaypointCreate);
+    };
+  }, [setNodes]);
+
+  useEffect(() => {
+    function handleWaypointUpdate(e: Event) {
+      const { detail } = e as CustomEvent<WayPointUpdateType>;
+      const newWp = detail.WAYPOINT;
+
+      setNodes((nds) => {
+        const nodeId = `waypoint:${newWp.id}`;
+        const existingNode = nds.find((node) => node.id === nodeId);
+
+        if (!existingNode) {
+          console.error('정보를 동기화하는 과정에서 문제가 있었습니다.');
+        }
+
+        return nds.map((node) =>
+          node.id === nodeId
+            ? ({
+                ...node,
+                position: {
+                  x: newWp.xPosition ?? node.position.x,
+                  y: newWp.yPosition ?? node.position.y,
+                },
+                data: {
+                  ...newWp,
+                },
+              } as WaypointNodeType)
+            : node
+        );
+      });
+    }
+
+    socketEventBus.addEventListener('WAYPOINT_UPDATE', handleWaypointUpdate);
+    return () => {
+      socketEventBus.removeEventListener('WAYPOINT_UPDATE', handleWaypointUpdate);
     };
   }, [setNodes]);
 

--- a/src/pages/plan/hooks/useDataSyncMemo.ts
+++ b/src/pages/plan/hooks/useDataSyncMemo.ts
@@ -46,7 +46,7 @@ export function useDataSyncMemo({ id, data }: { id: string; data: MemoData }) {
     };
   }, [data]);
 
-  const handleLocalDataChange = (field: keyof MemoData, value: any) => {
+  const handleLocalDataChange = <K extends keyof MemoData>(field: K, value: MemoData[K]) => {
     localUpdateRef.current = true;
     setNodes((nds) =>
       nds.map((node) =>

--- a/src/pages/plan/hooks/useDataSyncMemo.ts
+++ b/src/pages/plan/hooks/useDataSyncMemo.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+import { useSocket } from './useSocket';
+import StompURL from '../utils/StompURL';
+import { useReactFlow } from '@xyflow/react';
+import type { MemoData } from '../flow/canvasComponents/Memo';
+
+export function useDataSyncMemo({ id, data }: { id: string; data: MemoData }) {
+  const isInitialRender = useRef(true);
+  const prevDataRef = useRef<MemoData>(data);
+  const { planId, client } = useSocket();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const DEBOUNCE_TIME = 300;
+  const { setNodes } = useReactFlow();
+  const localUpdateRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      prevDataRef.current = data;
+      return;
+    }
+
+    // 디바운싱
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      const prev = prevDataRef.current;
+      const changed = JSON.stringify(prev) !== JSON.stringify(data);
+
+      if (changed && localUpdateRef.current) {
+        client.publish({
+          destination: StompURL.PUB.MEMO.UPDATE(planId, data.id),
+          body: JSON.stringify(data),
+        });
+
+        prevDataRef.current = data;
+      }
+    }, DEBOUNCE_TIME);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [data]);
+
+  const handleLocalDataChange = (field: keyof MemoData, value: any) => {
+    localUpdateRef.current = true;
+    setNodes((nds) =>
+      nds.map((node) =>
+        node.id === id.toString() ? { ...node, data: { ...node.data, [field]: value } } : node
+      )
+    );
+  };
+
+  return { handleLocalDataChange };
+}

--- a/src/pages/plan/hooks/useDataSyncWaypoint.ts
+++ b/src/pages/plan/hooks/useDataSyncWaypoint.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+import type { WaypointData } from '../flow/canvasComponents/Waypoint';
+
+export function useDataSyncWaypoint({ data }: { data: WaypointData }) {
+  const isInitialRender = useRef(true);
+  const prevDataRef = useRef<WaypointData>(data);
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      prevDataRef.current = data;
+      return;
+    }
+
+    const prev = prevDataRef.current;
+    const changed = JSON.stringify(prev) !== JSON.stringify(data);
+
+    if (changed) {
+      console.log('웨이포인트 웹 소켓 데이터 전송', data);
+      prevDataRef.current = data;
+    }
+  }, [data]);
+}

--- a/src/pages/plan/hooks/useDataSyncWaypoint.ts
+++ b/src/pages/plan/hooks/useDataSyncWaypoint.ts
@@ -1,9 +1,15 @@
 import { useEffect, useRef } from 'react';
 import type { WaypointData } from '../flow/canvasComponents/Waypoint';
+import { useSocket } from './useSocket';
+import StompURL from '../utils/StompURL';
 
 export function useDataSyncWaypoint({ data }: { data: WaypointData }) {
   const isInitialRender = useRef(true);
   const prevDataRef = useRef<WaypointData>(data);
+  const { planId, client } = useSocket();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const DEBOUNCE_TIME = 300;
+
   useEffect(() => {
     if (isInitialRender.current) {
       isInitialRender.current = false;
@@ -11,12 +17,29 @@ export function useDataSyncWaypoint({ data }: { data: WaypointData }) {
       return;
     }
 
-    const prev = prevDataRef.current;
-    const changed = JSON.stringify(prev) !== JSON.stringify(data);
-
-    if (changed) {
-      console.log('웨이포인트 웹 소켓 데이터 전송', data);
-      prevDataRef.current = data;
+    // 디바운싱
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
     }
+
+    timeoutRef.current = setTimeout(() => {
+      const prev = prevDataRef.current;
+      const changed = JSON.stringify(prev) !== JSON.stringify(data);
+
+      if (changed) {
+        client.publish({
+          destination: StompURL.PUB.WAYPOINT.UPDATE(planId, data.id),
+          body: JSON.stringify(data),
+        });
+
+        prevDataRef.current = data;
+      }
+    }, DEBOUNCE_TIME);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
   }, [data]);
 }

--- a/src/pages/plan/hooks/useDataSyncWaypoint.ts
+++ b/src/pages/plan/hooks/useDataSyncWaypoint.ts
@@ -2,13 +2,16 @@ import { useEffect, useRef } from 'react';
 import type { WaypointData } from '../flow/canvasComponents/Waypoint';
 import { useSocket } from './useSocket';
 import StompURL from '../utils/StompURL';
+import { useReactFlow } from '@xyflow/react';
 
-export function useDataSyncWaypoint({ data }: { data: WaypointData }) {
+export function useDataSyncWaypoint({ id, data }: { id: string; data: WaypointData }) {
   const isInitialRender = useRef(true);
   const prevDataRef = useRef<WaypointData>(data);
   const { planId, client } = useSocket();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const DEBOUNCE_TIME = 300;
+  const { setNodes } = useReactFlow();
+  const localUpdateRef = useRef<boolean>(false);
 
   useEffect(() => {
     if (isInitialRender.current) {
@@ -26,7 +29,7 @@ export function useDataSyncWaypoint({ data }: { data: WaypointData }) {
       const prev = prevDataRef.current;
       const changed = JSON.stringify(prev) !== JSON.stringify(data);
 
-      if (changed) {
+      if (changed && localUpdateRef.current) {
         client.publish({
           destination: StompURL.PUB.WAYPOINT.UPDATE(planId, data.id),
           body: JSON.stringify(data),
@@ -42,4 +45,15 @@ export function useDataSyncWaypoint({ data }: { data: WaypointData }) {
       }
     };
   }, [data]);
+
+  const handleLocalDataChange = (field: keyof WaypointData, value: any) => {
+    localUpdateRef.current = true;
+    setNodes((nds) =>
+      nds.map((node) =>
+        node.id === id.toString() ? { ...node, data: { ...node.data, [field]: value } } : node
+      )
+    );
+  };
+
+  return { handleLocalDataChange };
 }

--- a/src/pages/plan/hooks/useDataSyncWaypoint.ts
+++ b/src/pages/plan/hooks/useDataSyncWaypoint.ts
@@ -46,7 +46,10 @@ export function useDataSyncWaypoint({ id, data }: { id: string; data: WaypointDa
     };
   }, [data]);
 
-  const handleLocalDataChange = (field: keyof WaypointData, value: any) => {
+  const handleLocalDataChange = <K extends keyof WaypointData>(
+    field: K,
+    value: WaypointData[K]
+  ) => {
     localUpdateRef.current = true;
     setNodes((nds) =>
       nds.map((node) =>

--- a/src/pages/plan/hooks/useSocket.ts
+++ b/src/pages/plan/hooks/useSocket.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { SocketContext } from '../context/SocketContext';
+
+export const useSocket = () => {
+  const context = useContext(SocketContext);
+  if (!context) throw new Error('useSocket must be used within a SocketProvider');
+  return context;
+};

--- a/src/pages/plan/hooks/useSocketHandler.tsx
+++ b/src/pages/plan/hooks/useSocketHandler.tsx
@@ -2,8 +2,12 @@ import SockJS from 'sockjs-client';
 import { Client } from '@stomp/stompjs';
 import { useEffect, useMemo } from 'react';
 import StompURL from '../utils/StompURL';
-import type { WayPointResponseType, WayPointCreateType } from '../types/WaypointResponseBodyType';
-import type { MemoCreateType, MemoResponseType } from '../types/MemoResponseBodyType';
+import type {
+  WayPointResponseType,
+  WayPointCreateType,
+  WayPointInitType,
+} from '../types/WaypointResponseBodyType';
+import type { MemoCreateType, MemoInitType, MemoResponseType } from '../types/MemoResponseBodyType';
 
 const API_BASE_URL = (import.meta as any).env?.VITE_API_BASE_URL || '/api';
 
@@ -52,6 +56,15 @@ export default function useSocketHandler({ planId }: useSocketHandlerType) {
       const wpData: WayPointResponseType = JSON.parse(message.body);
       console.log('WAYPOINT 메시지:', wpData);
       switch (wpData.type) {
+        case 'WAYPOINT_INIT':
+          const wpInit = wpData as WayPointInitType;
+          for (let i = 0; i < wpInit.waypoints.length; i++) {
+            const waypoint = wpInit.waypoints[i];
+            socketEventBus.dispatchEvent(
+              new CustomEvent('WAYPOINT_CREATE', { detail: { waypoint } })
+            );
+          }
+          break;
         case 'WAYPOINT_CREATE':
           const wpCreate = wpData as WayPointCreateType;
           socketEventBus.dispatchEvent(new CustomEvent('WAYPOINT_CREATE', { detail: wpCreate }));
@@ -62,6 +75,13 @@ export default function useSocketHandler({ planId }: useSocketHandlerType) {
       const memoData: MemoResponseType = JSON.parse(message.body);
       console.log('WAYPOINT 메시지:', memoData);
       switch (memoData.type) {
+        case 'MEMO_INIT':
+          const memoInit = memoData as MemoInitType;
+          for (let i = 0; i < memoInit.memos.length; i++) {
+            const memo = memoInit.memos[i];
+            socketEventBus.dispatchEvent(new CustomEvent('MEMO_CREATE', { detail: { memo } }));
+          }
+          break;
         case 'MEMO_CREATE':
           const memoCreate = memoData as MemoCreateType;
           socketEventBus.dispatchEvent(new CustomEvent('MEMO_CREATE', { detail: memoCreate }));

--- a/src/pages/plan/hooks/useSocketHandler.tsx
+++ b/src/pages/plan/hooks/useSocketHandler.tsx
@@ -15,12 +15,13 @@ export default function useSocketHandler({ planId }: useSocketHandlerType) {
       new Client({
         webSocketFactory: () => new SockJS(`${API_BASE_URL}/ws`),
         onConnect: () => {
-          console.log('연결 성공');
           subscribeAll();
+          initAll();
+          console.log('Stomp 연결 성공');
         },
-        debug: (str) => {
-          console.log(new Date(), str);
-        },
+        // debug: (str) => {
+        //   console.log(new Date(), str);
+        // },
       }),
     [planId]
   );
@@ -55,6 +56,19 @@ export default function useSocketHandler({ planId }: useSocketHandlerType) {
     client.subscribe(StompURL.SUB.TRAVELER(planId), (message) => {
       console.log('TRAVELER 메시지:', JSON.parse(message.body));
     });
+  }
+
+  function initAll() {
+    client.publish({
+      destination: StompURL.PUB.WAYPOINT.INIT(planId),
+    });
+    client.publish({
+      destination: StompURL.PUB.MEMO.INIT(planId),
+    });
+    client.publish({
+      destination: StompURL.PUB.ROUTE.INIT(planId),
+    });
+    //TRAVELER init 작업 추후에 수행
   }
 
   useEffect(() => {

--- a/src/pages/plan/hooks/useSocketHandler.tsx
+++ b/src/pages/plan/hooks/useSocketHandler.tsx
@@ -3,6 +3,8 @@ import { useEffect, useMemo } from 'react';
 import StompURL from '../utils/StompURL';
 import { WaypointDispatcherResolver } from '../utils/WaypointDispatcherResolver';
 import { MemoDispatcherResolver } from '../utils/MemoDispatcherResolver';
+import { initDependencies } from '../utils/InitDependencies';
+import { topologicalSort } from '../utils/Topology';
 
 const API_BASE_URL = (import.meta as any).env?.VITE_API_BASE_URL || '/api';
 
@@ -57,17 +59,46 @@ export default function useSocketHandler({ planId }: useSocketHandlerType) {
     });
   }
 
-  function initAll() {
-    client.publish({
-      destination: StompURL.PUB.WAYPOINT.INIT(planId),
+  function waitForInitComplete(eventName: string, timeout = 5000): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const handler = () => {
+        socketEventBus.removeEventListener(eventName, handler);
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        socketEventBus.removeEventListener(eventName, handler);
+        reject(new Error(`${eventName} timeout`));
+      }, timeout);
+
+      socketEventBus.addEventListener(eventName, handler);
     });
-    client.publish({
-      destination: StompURL.PUB.MEMO.INIT(planId),
-    });
-    client.publish({
-      destination: StompURL.PUB.ROUTE.INIT(planId),
-    });
-    //TRAVELER init 작업 추후에 수행
+  }
+
+  async function initAll() {
+    const sorted = topologicalSort(initDependencies);
+    console.log('Init 순서:', sorted);
+
+    for (const target of sorted) {
+      switch (target) {
+        case 'WAYPOINT':
+          client.publish({ destination: StompURL.PUB.WAYPOINT.INIT(planId) });
+          await waitForInitComplete('WAYPOINT_INIT_DONE');
+          break;
+        case 'MEMO':
+          client.publish({ destination: StompURL.PUB.MEMO.INIT(planId) });
+          await waitForInitComplete('MEMO_INIT_DONE');
+          break;
+        case 'ROUTE':
+          client.publish({ destination: StompURL.PUB.ROUTE.INIT(planId) });
+          // TBD: await waitForInitComplete('ROUTE_INIT_DONE');
+          break;
+        case 'TRAVELER':
+          // TBD
+          break;
+      }
+      console.log(`[INIT] ${target} 초기화 완료`);
+    }
   }
 
   useEffect(() => {

--- a/src/pages/plan/hooks/useSocketHandler.tsx
+++ b/src/pages/plan/hooks/useSocketHandler.tsx
@@ -1,4 +1,3 @@
-import SockJS from 'sockjs-client';
 import { Client } from '@stomp/stompjs';
 import { useEffect, useMemo } from 'react';
 import StompURL from '../utils/StompURL';
@@ -17,7 +16,7 @@ export default function useSocketHandler({ planId }: useSocketHandlerType) {
   const client = useMemo(
     () =>
       new Client({
-        webSocketFactory: () => new SockJS(`${API_BASE_URL}/ws`),
+        webSocketFactory: () => new WebSocket(`${API_BASE_URL}/ws`),
         onConnect: () => {
           subscribeAll();
           initAll();

--- a/src/pages/plan/hooks/useSocketHandler.tsx
+++ b/src/pages/plan/hooks/useSocketHandler.tsx
@@ -2,12 +2,16 @@ import SockJS from 'sockjs-client';
 import { Client } from '@stomp/stompjs';
 import { useEffect, useMemo } from 'react';
 import StompURL from '../utils/StompURL';
+import type { WayPointResponseType, WayPointCreateType } from '../types/WaypointResponseBodyType';
+import type { MemoCreateType, MemoResponseType } from '../types/MemoResponseBodyType';
 
 const API_BASE_URL = (import.meta as any).env?.VITE_API_BASE_URL || '/api';
 
 type useSocketHandlerType = {
   planId: number;
 };
+
+export const socketEventBus = new EventTarget();
 
 export default function useSocketHandler({ planId }: useSocketHandlerType) {
   const client = useMemo(
@@ -45,10 +49,24 @@ export default function useSocketHandler({ planId }: useSocketHandlerType) {
       }
     });
     client.subscribe(StompURL.SUB.WAYPOINT(planId), (message) => {
-      console.log('WAYPOINT 메시지:', JSON.parse(message.body));
+      const wpData: WayPointResponseType = JSON.parse(message.body);
+      console.log('WAYPOINT 메시지:', wpData);
+      switch (wpData.type) {
+        case 'WAYPOINT_CREATE':
+          const wpCreate = wpData as WayPointCreateType;
+          socketEventBus.dispatchEvent(new CustomEvent('WAYPOINT_CREATE', { detail: wpCreate }));
+          break;
+      }
     });
     client.subscribe(StompURL.SUB.MEMO(planId), (message) => {
-      console.log('MEMO 메시지:', JSON.parse(message.body));
+      const memoData: MemoResponseType = JSON.parse(message.body);
+      console.log('WAYPOINT 메시지:', memoData);
+      switch (memoData.type) {
+        case 'MEMO_CREATE':
+          const memoCreate = memoData as MemoCreateType;
+          socketEventBus.dispatchEvent(new CustomEvent('MEMO_CREATE', { detail: memoCreate }));
+          break;
+      }
     });
     client.subscribe(StompURL.SUB.ROUTE(planId), (message) => {
       console.log('ROUTE 메시지:', JSON.parse(message.body));

--- a/src/pages/plan/hooks/useSocketHandler.tsx
+++ b/src/pages/plan/hooks/useSocketHandler.tsx
@@ -1,0 +1,69 @@
+import SockJS from 'sockjs-client';
+import { Client } from '@stomp/stompjs';
+import { useEffect, useMemo } from 'react';
+import StompURL from '../utils/StompURL';
+
+const API_BASE_URL = (import.meta as any).env?.VITE_API_BASE_URL || '/api';
+
+type useSocketHandlerType = {
+  planId: number;
+};
+
+export default function useSocketHandler({ planId }: useSocketHandlerType) {
+  const client = useMemo(
+    () =>
+      new Client({
+        webSocketFactory: () => new SockJS(`${API_BASE_URL}/ws`),
+        onConnect: () => {
+          console.log('연결 성공');
+          subscribeAll();
+        },
+        debug: (str) => {
+          console.log(new Date(), str);
+        },
+      }),
+    [planId]
+  );
+
+  function connect() {
+    client.activate();
+  }
+
+  function disconnect() {
+    client.deactivate();
+  }
+
+  function subscribeAll() {
+    client.subscribe(StompURL.SUB.ERROR, (msg) => {
+      console.log('❌ Error: ' + msg.body, 'error');
+      try {
+        const error = JSON.parse(msg.body);
+        console.error(`에러 발생!\n[${error.code}] ${error.message}`);
+      } catch (e) {
+        console.error('에러 발생!\n' + msg.body);
+      }
+    });
+    client.subscribe(StompURL.SUB.WAYPOINT(planId), (message) => {
+      console.log('WAYPOINT 메시지:', JSON.parse(message.body));
+    });
+    client.subscribe(StompURL.SUB.MEMO(planId), (message) => {
+      console.log('MEMO 메시지:', JSON.parse(message.body));
+    });
+    client.subscribe(StompURL.SUB.ROUTE(planId), (message) => {
+      console.log('ROUTE 메시지:', JSON.parse(message.body));
+    });
+    client.subscribe(StompURL.SUB.TRAVELER(planId), (message) => {
+      console.log('TRAVELER 메시지:', JSON.parse(message.body));
+    });
+  }
+
+  useEffect(() => {
+    connect();
+
+    return disconnect;
+  }, [client]);
+
+  return {
+    client,
+  };
+}

--- a/src/pages/plan/hooks/useSocketHandler.tsx
+++ b/src/pages/plan/hooks/useSocketHandler.tsx
@@ -2,12 +2,8 @@ import SockJS from 'sockjs-client';
 import { Client } from '@stomp/stompjs';
 import { useEffect, useMemo } from 'react';
 import StompURL from '../utils/StompURL';
-import type {
-  WayPointResponseType,
-  WayPointCreateType,
-  WayPointInitType,
-} from '../types/WaypointResponseBodyType';
-import type { MemoCreateType, MemoInitType, MemoResponseType } from '../types/MemoResponseBodyType';
+import { WaypointDispatcherResolver } from '../utils/WaypointDispatcherResolver';
+import { MemoDispatcherResolver } from '../utils/MemoDispatcherResolver';
 
 const API_BASE_URL = (import.meta as any).env?.VITE_API_BASE_URL || '/api';
 
@@ -52,42 +48,8 @@ export default function useSocketHandler({ planId }: useSocketHandlerType) {
         console.error('에러 발생!\n' + msg.body);
       }
     });
-    client.subscribe(StompURL.SUB.WAYPOINT(planId), (message) => {
-      const wpData: WayPointResponseType = JSON.parse(message.body);
-      console.log('WAYPOINT 메시지:', wpData);
-      switch (wpData.type) {
-        case 'WAYPOINT_INIT':
-          const wpInit = wpData as WayPointInitType;
-          for (let i = 0; i < wpInit.waypoints.length; i++) {
-            const waypoint = wpInit.waypoints[i];
-            socketEventBus.dispatchEvent(
-              new CustomEvent('WAYPOINT_CREATE', { detail: { waypoint } })
-            );
-          }
-          break;
-        case 'WAYPOINT_CREATE':
-          const wpCreate = wpData as WayPointCreateType;
-          socketEventBus.dispatchEvent(new CustomEvent('WAYPOINT_CREATE', { detail: wpCreate }));
-          break;
-      }
-    });
-    client.subscribe(StompURL.SUB.MEMO(planId), (message) => {
-      const memoData: MemoResponseType = JSON.parse(message.body);
-      console.log('WAYPOINT 메시지:', memoData);
-      switch (memoData.type) {
-        case 'MEMO_INIT':
-          const memoInit = memoData as MemoInitType;
-          for (let i = 0; i < memoInit.memos.length; i++) {
-            const memo = memoInit.memos[i];
-            socketEventBus.dispatchEvent(new CustomEvent('MEMO_CREATE', { detail: { memo } }));
-          }
-          break;
-        case 'MEMO_CREATE':
-          const memoCreate = memoData as MemoCreateType;
-          socketEventBus.dispatchEvent(new CustomEvent('MEMO_CREATE', { detail: memoCreate }));
-          break;
-      }
-    });
+    client.subscribe(StompURL.SUB.WAYPOINT(planId), WaypointDispatcherResolver);
+    client.subscribe(StompURL.SUB.MEMO(planId), MemoDispatcherResolver);
     client.subscribe(StompURL.SUB.ROUTE(planId), (message) => {
       console.log('ROUTE 메시지:', JSON.parse(message.body));
     });

--- a/src/pages/plan/types/InitTask.ts
+++ b/src/pages/plan/types/InitTask.ts
@@ -1,0 +1,1 @@
+export type InitTask = 'WAYPOINT' | 'MEMO' | 'ROUTE' | 'TRAVELER';

--- a/src/pages/plan/types/MemoResponseBodyType.ts
+++ b/src/pages/plan/types/MemoResponseBodyType.ts
@@ -1,0 +1,10 @@
+import type { MemoData } from '../flow/canvasComponents/Memo';
+
+export type MemoResponseType = {
+  type: `MEMO_CREATE`;
+};
+
+export type MemoCreateType = {
+  type: 'MEMO_CREATE';
+  memo: MemoData;
+};

--- a/src/pages/plan/types/MemoResponseBodyType.ts
+++ b/src/pages/plan/types/MemoResponseBodyType.ts
@@ -1,15 +1,15 @@
 import type { MemoData } from '../flow/canvasComponents/Memo';
 
 export type MemoResponseType = {
-  type: `MEMO_CREATE` | `MEMO_INIT`;
+  type: `CREATE` | `INIT`;
 };
 
 export type MemoCreateType = {
-  type: 'MEMO_CREATE';
-  memo: MemoData;
+  type: 'CREATE';
+  MEMO: MemoData;
 };
 
 export type MemoInitType = {
-  type: 'MEMO_INIT';
-  memos: MemoData[];
+  type: 'INIT';
+  MEMO: MemoData[];
 };

--- a/src/pages/plan/types/MemoResponseBodyType.ts
+++ b/src/pages/plan/types/MemoResponseBodyType.ts
@@ -1,7 +1,7 @@
 import type { MemoData } from '../flow/canvasComponents/Memo';
 
 export type MemoResponseType = {
-  type: `CREATE` | `INIT`;
+  type: `CREATE` | `INIT` | `UPDATE`;
 };
 
 export type MemoCreateType = {
@@ -12,4 +12,9 @@ export type MemoCreateType = {
 export type MemoInitType = {
   type: 'INIT';
   MEMO: MemoData[];
+};
+
+export type MemoUpdateType = {
+  type: 'UPDATE';
+  MEMO: MemoData;
 };

--- a/src/pages/plan/types/MemoResponseBodyType.ts
+++ b/src/pages/plan/types/MemoResponseBodyType.ts
@@ -1,10 +1,15 @@
 import type { MemoData } from '../flow/canvasComponents/Memo';
 
 export type MemoResponseType = {
-  type: `MEMO_CREATE`;
+  type: `MEMO_CREATE` | `MEMO_INIT`;
 };
 
 export type MemoCreateType = {
   type: 'MEMO_CREATE';
   memo: MemoData;
+};
+
+export type MemoInitType = {
+  type: 'MEMO_INIT';
+  memos: MemoData[];
 };

--- a/src/pages/plan/types/WaypointResponseBodyType.ts
+++ b/src/pages/plan/types/WaypointResponseBodyType.ts
@@ -1,0 +1,10 @@
+import { type WaypointData } from '../flow/canvasComponents/Waypoint';
+
+export type WayPointResponseType = {
+  type: `WAYPOINT_CREATE`;
+};
+
+export type WayPointCreateType = {
+  type: 'WAYPOINT_CREATE';
+  waypoint: WaypointData;
+};

--- a/src/pages/plan/types/WaypointResponseBodyType.ts
+++ b/src/pages/plan/types/WaypointResponseBodyType.ts
@@ -1,7 +1,7 @@
 import { type WaypointData } from '../flow/canvasComponents/Waypoint';
 
 export type WayPointResponseType = {
-  type: `CREATE` | `INIT`;
+  type: `CREATE` | `INIT` | `UPDATE`;
 };
 
 export type WayPointCreateType = {
@@ -12,4 +12,9 @@ export type WayPointCreateType = {
 export type WayPointInitType = {
   type: 'INIT';
   WAYPOINT: WaypointData[];
+};
+
+export type WayPointUpdateType = {
+  type: 'UPDATE';
+  WAYPOINT: WaypointData;
 };

--- a/src/pages/plan/types/WaypointResponseBodyType.ts
+++ b/src/pages/plan/types/WaypointResponseBodyType.ts
@@ -1,10 +1,15 @@
 import { type WaypointData } from '../flow/canvasComponents/Waypoint';
 
 export type WayPointResponseType = {
-  type: `WAYPOINT_CREATE`;
+  type: `WAYPOINT_CREATE` | `WAYPOINT_INIT`;
 };
 
 export type WayPointCreateType = {
   type: 'WAYPOINT_CREATE';
   waypoint: WaypointData;
+};
+
+export type WayPointInitType = {
+  type: 'WAYPOINT_INIT';
+  waypoints: WaypointData[];
 };

--- a/src/pages/plan/types/WaypointResponseBodyType.ts
+++ b/src/pages/plan/types/WaypointResponseBodyType.ts
@@ -1,15 +1,15 @@
 import { type WaypointData } from '../flow/canvasComponents/Waypoint';
 
 export type WayPointResponseType = {
-  type: `WAYPOINT_CREATE` | `WAYPOINT_INIT`;
+  type: `CREATE` | `INIT`;
 };
 
 export type WayPointCreateType = {
-  type: 'WAYPOINT_CREATE';
-  waypoint: WaypointData;
+  type: 'CREATE';
+  WAYPOINT: WaypointData;
 };
 
 export type WayPointInitType = {
-  type: 'WAYPOINT_INIT';
-  waypoints: WaypointData[];
+  type: 'INIT';
+  WAYPOINT: WaypointData[];
 };

--- a/src/pages/plan/utils/InitDependencies.ts
+++ b/src/pages/plan/utils/InitDependencies.ts
@@ -1,4 +1,6 @@
-export const initDependencies: Record<InitTaskName, InitTaskName[]> = {
+import type { InitTask } from '../types/InitTask';
+
+export const initDependencies: Record<InitTask, InitTask[]> = {
   WAYPOINT: [],
   MEMO: ['WAYPOINT'], // MEMO는 WAYPOINT 이후
   ROUTE: ['WAYPOINT'], // ROUTE도 WAYPOINT 이후

--- a/src/pages/plan/utils/InitDependencies.ts
+++ b/src/pages/plan/utils/InitDependencies.ts
@@ -1,0 +1,6 @@
+export const initDependencies: Record<InitTaskName, InitTaskName[]> = {
+  WAYPOINT: [],
+  MEMO: ['WAYPOINT'], // MEMO는 WAYPOINT 이후
+  ROUTE: ['WAYPOINT'], // ROUTE도 WAYPOINT 이후
+  TRAVELER: ['ROUTE'], // TRAVELER는 ROUTE 이후
+};

--- a/src/pages/plan/utils/MemoDispatcherResolver.ts
+++ b/src/pages/plan/utils/MemoDispatcherResolver.ts
@@ -1,0 +1,20 @@
+import { socketEventBus } from '../hooks/useSocketHandler';
+import type { MemoCreateType, MemoInitType, MemoResponseType } from '../types/MemoResponseBodyType';
+
+export function MemoDispatcherResolver(message: any) {
+  const memoData: MemoResponseType = JSON.parse(message.body);
+  console.log('WAYPOINT 메시지:', memoData);
+  switch (memoData.type) {
+    case 'MEMO_INIT':
+      const memoInit = memoData as MemoInitType;
+      for (let i = 0; i < memoInit.memos.length; i++) {
+        const memo = memoInit.memos[i];
+        socketEventBus.dispatchEvent(new CustomEvent('MEMO_CREATE', { detail: { memo } }));
+      }
+      break;
+    case 'MEMO_CREATE':
+      const memoCreate = memoData as MemoCreateType;
+      socketEventBus.dispatchEvent(new CustomEvent('MEMO_CREATE', { detail: memoCreate }));
+      break;
+  }
+}

--- a/src/pages/plan/utils/MemoDispatcherResolver.ts
+++ b/src/pages/plan/utils/MemoDispatcherResolver.ts
@@ -3,18 +3,22 @@ import type { MemoCreateType, MemoInitType, MemoResponseType } from '../types/Me
 
 export function MemoDispatcherResolver(message: any) {
   const memoData: MemoResponseType = JSON.parse(message.body);
-  console.log('WAYPOINT 메시지:', memoData);
+  console.log('MEMO 메시지:', memoData);
   switch (memoData.type) {
-    case 'MEMO_INIT':
+    case 'INIT':
       const memoInit = memoData as MemoInitType;
-      for (let i = 0; i < memoInit.memos.length; i++) {
-        const memo = memoInit.memos[i];
-        socketEventBus.dispatchEvent(new CustomEvent('MEMO_CREATE', { detail: { memo } }));
+      for (let i = 0; i < memoInit.MEMO.length; i++) {
+        const memo = memoInit.MEMO[i];
+        socketEventBus.dispatchEvent(
+          new CustomEvent('MEMO_CREATE', { detail: { MEMO: { ...memo } } })
+        );
       }
       break;
-    case 'MEMO_CREATE':
-      const memoCreate = memoData as MemoCreateType;
-      socketEventBus.dispatchEvent(new CustomEvent('MEMO_CREATE', { detail: memoCreate }));
+    case 'CREATE':
+      const memoCreate = (memoData as MemoCreateType).MEMO;
+      socketEventBus.dispatchEvent(
+        new CustomEvent('MEMO_CREATE', { detail: { MEMO: { ...memoCreate } } })
+      );
       break;
   }
 }

--- a/src/pages/plan/utils/MemoDispatcherResolver.ts
+++ b/src/pages/plan/utils/MemoDispatcherResolver.ts
@@ -1,5 +1,10 @@
 import { socketEventBus } from '../hooks/useSocketHandler';
-import type { MemoCreateType, MemoInitType, MemoResponseType } from '../types/MemoResponseBodyType';
+import type {
+  MemoCreateType,
+  MemoInitType,
+  MemoResponseType,
+  MemoUpdateType,
+} from '../types/MemoResponseBodyType';
 
 export function MemoDispatcherResolver(message: any) {
   const memoData: MemoResponseType = JSON.parse(message.body);
@@ -18,6 +23,12 @@ export function MemoDispatcherResolver(message: any) {
       const memoCreate = (memoData as MemoCreateType).MEMO;
       socketEventBus.dispatchEvent(
         new CustomEvent('MEMO_CREATE', { detail: { MEMO: { ...memoCreate } } })
+      );
+      break;
+    case 'UPDATE':
+      const memoUpdate = (memoData as MemoUpdateType).MEMO;
+      socketEventBus.dispatchEvent(
+        new CustomEvent('MEMO_UPDATE', { detail: { MEMO: { ...memoUpdate } } })
       );
       break;
   }

--- a/src/pages/plan/utils/MemoDispatcherResolver.ts
+++ b/src/pages/plan/utils/MemoDispatcherResolver.ts
@@ -18,6 +18,7 @@ export function MemoDispatcherResolver(message: any) {
           new CustomEvent('MEMO_CREATE', { detail: { MEMO: { ...memo } } })
         );
       }
+      socketEventBus.dispatchEvent(new Event('MEMO_INIT_DONE'));
       break;
     case 'CREATE':
       const memoCreate = (memoData as MemoCreateType).MEMO;

--- a/src/pages/plan/utils/MemoDispatcherResolver.ts
+++ b/src/pages/plan/utils/MemoDispatcherResolver.ts
@@ -1,3 +1,4 @@
+import type { Message } from '@stomp/stompjs';
 import { socketEventBus } from '../hooks/useSocketHandler';
 import type {
   MemoCreateType,
@@ -6,7 +7,7 @@ import type {
   MemoUpdateType,
 } from '../types/MemoResponseBodyType';
 
-export function MemoDispatcherResolver(message: any) {
+export function MemoDispatcherResolver(message: Message) {
   const memoData: MemoResponseType = JSON.parse(message.body);
   console.log('MEMO 메시지:', memoData);
   switch (memoData.type) {

--- a/src/pages/plan/utils/MemoDispatcherResolver.ts
+++ b/src/pages/plan/utils/MemoDispatcherResolver.ts
@@ -11,7 +11,7 @@ export function MemoDispatcherResolver(message: Message) {
   const memoData: MemoResponseType = JSON.parse(message.body);
   console.log('MEMO 메시지:', memoData);
   switch (memoData.type) {
-    case 'INIT':
+    case 'INIT': {
       const memoInit = memoData as MemoInitType;
       for (let i = 0; i < memoInit.MEMO.length; i++) {
         const memo = memoInit.MEMO[i];
@@ -21,17 +21,20 @@ export function MemoDispatcherResolver(message: Message) {
       }
       socketEventBus.dispatchEvent(new Event('MEMO_INIT_DONE'));
       break;
-    case 'CREATE':
+    }
+    case 'CREATE': {
       const memoCreate = (memoData as MemoCreateType).MEMO;
       socketEventBus.dispatchEvent(
         new CustomEvent('MEMO_CREATE', { detail: { MEMO: { ...memoCreate } } })
       );
       break;
-    case 'UPDATE':
+    }
+    case 'UPDATE': {
       const memoUpdate = (memoData as MemoUpdateType).MEMO;
       socketEventBus.dispatchEvent(
         new CustomEvent('MEMO_UPDATE', { detail: { MEMO: { ...memoUpdate } } })
       );
       break;
+    }
   }
 }

--- a/src/pages/plan/utils/StompURL.ts
+++ b/src/pages/plan/utils/StompURL.ts
@@ -1,0 +1,36 @@
+export default {
+  SUB: {
+    ERROR: `/user/queue/errors`,
+    WAYPOINT: (planId: number) => `/topic/plans/${planId}/waypoints`,
+    MEMO: (planId: number) => `/topic/plans/${planId}/memos`,
+    ROUTE: (planId: number) => `/topic/plans/${planId}/routes`,
+    TRAVELER: (planId: number) => `/topic/plans/${planId}/travelers`,
+  },
+  PUB: {
+    WAYPOINT: {
+      INIT: (planId: number) => `/app/plans/${planId}/waypoints/init`,
+      CREATE: (planId: number) => `/app/plans/${planId}/waypoints/create`,
+      UPDATE: (planId: number, waypointId: number) =>
+        `/app/plans/${planId}/waypoints/${waypointId}/update`,
+      DELETE: (planId: number, waypointId: number) =>
+        `/app/plans/${planId}/waypoints/${waypointId}/delete`,
+    },
+    MEMO: {
+      INIT: (planId: number) => `/app/plans/${planId}/memos/init`,
+      CREATE: (planId: number) => `/app/plans/${planId}/memos/create`,
+      UPDATE: (planId: number, memoId: number) => `/app/plans/${planId}/memos/${memoId}/update`,
+      DELETE: (planId: number, memoId: number) => `/app/plans/${planId}/memos/${memoId}/delete`,
+    },
+    ROUTE: {
+      INIT: (planId: number) => `/app/plans/${planId}/routes/init`,
+      CREATE: (planId: number) => `/app/plans/${planId}/routes/create`,
+      UPDATE: (planId: number, routeId: number) => `/app/plans/${planId}/routes/${routeId}/update`,
+      DELETE: (planId: number, routeId: number) => `/app/plans/${planId}/routes/${routeId}/delete`,
+    },
+    TRAVELER: {
+      INIT: (planId: number) => `/app/plans/${planId}/travelers/init`,
+      DELETE: (planId: number, travelerId: number) =>
+        `/app/plans/${planId}/travelers/${travelerId}/delete`,
+    },
+  },
+} as const;

--- a/src/pages/plan/utils/Topology.ts
+++ b/src/pages/plan/utils/Topology.ts
@@ -1,0 +1,36 @@
+import type { InitTask } from '../types/InitTask';
+
+export function topologicalSort(dependencies: Record<InitTask, InitTask[]>): InitTask[] {
+  const indegree = new Map<InitTask, number>();
+  const graph = new Map<InitTask, InitTask[]>();
+
+  Object.keys(dependencies).forEach((node) => {
+    const deps = dependencies[node as InitTask];
+    indegree.set(node as InitTask, deps.length);
+    deps.forEach((dep) => {
+      if (!graph.has(dep)) graph.set(dep, []);
+      graph.get(dep)!.push(node as InitTask);
+    });
+  });
+
+  const queue: InitTask[] = [];
+  for (const [node, deg] of indegree) {
+    if (deg === 0) queue.push(node);
+  }
+
+  const result: InitTask[] = [];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    result.push(current);
+    for (const next of graph.get(current) || []) {
+      indegree.set(next, indegree.get(next)! - 1);
+      if (indegree.get(next) === 0) queue.push(next);
+    }
+  }
+
+  if (result.length !== Object.keys(dependencies).length) {
+    throw new Error('Cyclic dependency detected in init tasks');
+  }
+
+  return result;
+}

--- a/src/pages/plan/utils/WaypointDispatcherResolver.ts
+++ b/src/pages/plan/utils/WaypointDispatcherResolver.ts
@@ -18,6 +18,7 @@ export function WaypointDispatcherResolver(message: any) {
           new CustomEvent('WAYPOINT_CREATE', { detail: { WAYPOINT: { ...waypoint } } })
         );
       }
+      socketEventBus.dispatchEvent(new Event('WAYPOINT_INIT_DONE'));
       break;
     case 'CREATE':
       const wpCreate = (wpData as WayPointCreateType).WAYPOINT;

--- a/src/pages/plan/utils/WaypointDispatcherResolver.ts
+++ b/src/pages/plan/utils/WaypointDispatcherResolver.ts
@@ -1,3 +1,4 @@
+import type { Message } from '@stomp/stompjs';
 import { socketEventBus } from '../hooks/useSocketHandler';
 import type {
   WayPointCreateType,
@@ -6,7 +7,7 @@ import type {
   WayPointUpdateType,
 } from '../types/WaypointResponseBodyType';
 
-export function WaypointDispatcherResolver(message: any) {
+export function WaypointDispatcherResolver(message: Message) {
   const wpData: WayPointResponseType = JSON.parse(message.body);
   console.log('WAYPOINT 메시지:', wpData);
   switch (wpData.type) {

--- a/src/pages/plan/utils/WaypointDispatcherResolver.ts
+++ b/src/pages/plan/utils/WaypointDispatcherResolver.ts
@@ -11,7 +11,7 @@ export function WaypointDispatcherResolver(message: Message) {
   const wpData: WayPointResponseType = JSON.parse(message.body);
   console.log('WAYPOINT 메시지:', wpData);
   switch (wpData.type) {
-    case 'INIT':
+    case 'INIT': {
       const wpInit = wpData as WayPointInitType;
       for (let i = 0; i < wpInit.WAYPOINT.length; i++) {
         const waypoint = wpInit.WAYPOINT[i];
@@ -21,17 +21,20 @@ export function WaypointDispatcherResolver(message: Message) {
       }
       socketEventBus.dispatchEvent(new Event('WAYPOINT_INIT_DONE'));
       break;
-    case 'CREATE':
+    }
+    case 'CREATE': {
       const wpCreate = (wpData as WayPointCreateType).WAYPOINT;
       socketEventBus.dispatchEvent(
         new CustomEvent('WAYPOINT_CREATE', { detail: { WAYPOINT: { ...wpCreate } } })
       );
       break;
-    case 'UPDATE':
+    }
+    case 'UPDATE': {
       const wpUpdate = (wpData as WayPointUpdateType).WAYPOINT;
       socketEventBus.dispatchEvent(
         new CustomEvent('WAYPOINT_UPDATE', { detail: { WAYPOINT: { ...wpUpdate } } })
       );
       break;
+    }
   }
 }

--- a/src/pages/plan/utils/WaypointDispatcherResolver.ts
+++ b/src/pages/plan/utils/WaypointDispatcherResolver.ts
@@ -3,6 +3,7 @@ import type {
   WayPointCreateType,
   WayPointInitType,
   WayPointResponseType,
+  WayPointUpdateType,
 } from '../types/WaypointResponseBodyType';
 
 export function WaypointDispatcherResolver(message: any) {
@@ -22,6 +23,12 @@ export function WaypointDispatcherResolver(message: any) {
       const wpCreate = (wpData as WayPointCreateType).WAYPOINT;
       socketEventBus.dispatchEvent(
         new CustomEvent('WAYPOINT_CREATE', { detail: { WAYPOINT: { ...wpCreate } } })
+      );
+      break;
+    case 'UPDATE':
+      const wpUpdate = (wpData as WayPointUpdateType).WAYPOINT;
+      socketEventBus.dispatchEvent(
+        new CustomEvent('WAYPOINT_UPDATE', { detail: { WAYPOINT: { ...wpUpdate } } })
       );
       break;
   }

--- a/src/pages/plan/utils/WaypointDispatcherResolver.ts
+++ b/src/pages/plan/utils/WaypointDispatcherResolver.ts
@@ -9,16 +9,20 @@ export function WaypointDispatcherResolver(message: any) {
   const wpData: WayPointResponseType = JSON.parse(message.body);
   console.log('WAYPOINT 메시지:', wpData);
   switch (wpData.type) {
-    case 'WAYPOINT_INIT':
+    case 'INIT':
       const wpInit = wpData as WayPointInitType;
-      for (let i = 0; i < wpInit.waypoints.length; i++) {
-        const waypoint = wpInit.waypoints[i];
-        socketEventBus.dispatchEvent(new CustomEvent('WAYPOINT_CREATE', { detail: { waypoint } }));
+      for (let i = 0; i < wpInit.WAYPOINT.length; i++) {
+        const waypoint = wpInit.WAYPOINT[i];
+        socketEventBus.dispatchEvent(
+          new CustomEvent('WAYPOINT_CREATE', { detail: { WAYPOINT: { ...waypoint } } })
+        );
       }
       break;
-    case 'WAYPOINT_CREATE':
-      const wpCreate = wpData as WayPointCreateType;
-      socketEventBus.dispatchEvent(new CustomEvent('WAYPOINT_CREATE', { detail: wpCreate }));
+    case 'CREATE':
+      const wpCreate = (wpData as WayPointCreateType).WAYPOINT;
+      socketEventBus.dispatchEvent(
+        new CustomEvent('WAYPOINT_CREATE', { detail: { WAYPOINT: { ...wpCreate } } })
+      );
       break;
   }
 }

--- a/src/pages/plan/utils/WaypointDispatcherResolver.ts
+++ b/src/pages/plan/utils/WaypointDispatcherResolver.ts
@@ -1,0 +1,24 @@
+import { socketEventBus } from '../hooks/useSocketHandler';
+import type {
+  WayPointCreateType,
+  WayPointInitType,
+  WayPointResponseType,
+} from '../types/WaypointResponseBodyType';
+
+export function WaypointDispatcherResolver(message: any) {
+  const wpData: WayPointResponseType = JSON.parse(message.body);
+  console.log('WAYPOINT 메시지:', wpData);
+  switch (wpData.type) {
+    case 'WAYPOINT_INIT':
+      const wpInit = wpData as WayPointInitType;
+      for (let i = 0; i < wpInit.waypoints.length; i++) {
+        const waypoint = wpInit.waypoints[i];
+        socketEventBus.dispatchEvent(new CustomEvent('WAYPOINT_CREATE', { detail: { waypoint } }));
+      }
+      break;
+    case 'WAYPOINT_CREATE':
+      const wpCreate = wpData as WayPointCreateType;
+      socketEventBus.dispatchEvent(new CustomEvent('WAYPOINT_CREATE', { detail: wpCreate }));
+      break;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,4 +10,7 @@ export default defineConfig({
   server: {
     port: 5173,
   },
+
+  /* Sock JS */
+  define: { global: 'window' },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,4 @@ export default defineConfig({
   server: {
     port: 5173,
   },
-
-  /* Sock JS */
-  define: { global: 'window' },
 });


### PR DESCRIPTION
# Stomp 웹 소켓 연결

## PR 수정 사항

계획 페이지 웹 소켓 연동 기능 구현

## **상세 설명**

계획 페이지 웹 소켓 연결 기능을 구현합니다.

### 캔버스 초기화
- [x] 캔버스 초기화시 구성 요소 init 순서 위상정렬 구조 도입
  - 메모와 간선 이전에 웨이포인트가 생성되어야 하고, 이러한 관계 제약 아래 확장 가능한 구조로 만들기 위해 위상정렬 개념을 도입하였습니다.

### 웨이포인트, 메모 노드
- [x] 초기 로드 요청 노드 생성
- [x] 생성 요청 실시간 동기화
- [x] 위치 및 내용에 대한 수정 요청 실시간 동기화

# 다음 PR에 포함될 것
- [ ] 삭제 기능 구현

### 이동 간선
- [ ] 초기 로드 요청 간선 생성
  - [ ] WaypointNode 생성 후 초기 로드 호출
- [ ] 생성 요청 실시간 동기화
- [ ] 내용에 대한 수정 요청 실시간 동기화
- [ ] 삭제 기능 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time socket provider and syncing for waypoints, memos, routes, and init sequencing.
  * Editable route edges with inline form and interactive edge labels.
  * Canvas toolbar now creates waypoints and memos centered in the current view.

* **Improvements**
  * Node positions persist on drag; live two-way sync for waypoint/memo edits.
  * Memo and waypoint fields renamed/standardized (id, name/title/content, camelCase positions).

* **Style**
  * Clickable edge label styling and layout adjustments for toolbar and canvas.

* **Chores**
  * Added STOMP WebSocket dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->