### PR TITLE
홈, 랜딩, 스페이스 페이지 기능구현, 수정

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,9 +1,10 @@
 import { useBlockScroll } from '@/hooks/useBlockScroll';
 import styled from 'styled-components';
+import { createPortal } from 'react-dom';
 
 function Modal({ children }: { children: React.ReactNode }) {
   useBlockScroll();
-  return <ModalWrapper>{children}</ModalWrapper>;
+  return createPortal(<ModalWrapper>{children}</ModalWrapper>, document.body);
 }
 
 const ModalWrapper = styled.div`
@@ -12,6 +13,7 @@ const ModalWrapper = styled.div`
   position: fixed;
   top: 0;
   left: 0;
+  z-index: 1000; /* 모든 일반 콘텐츠 위에 표시 */
 
   display: flex;
   justify-content: center;

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -8,28 +8,11 @@ import RoutingPanel from '@/components/dev/RoutingPanel';
 import RequireAuth from '@/components/routes/RequireAuth';
 import RequireGuest from '@/components/routes/RequireGuest';
 import { PATH } from '@utils/path';
-import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
+import { Outlet, Route, Routes } from 'react-router-dom';
 import styled from 'styled-components';
 import ColorPanel from './dev/ColorPanel';
 import FontPanel from './dev/FontPanel';
 import { ToastContainer } from 'react-toastify';
-import { useState, useEffect } from 'react';
-
-function RootRedirect() {
-  const [isFirstVisit] = useState(() => localStorage.getItem('isFirstVisit') === null);
-
-  useEffect(() => {
-    if (isFirstVisit) {
-      localStorage.setItem('isFirstVisit', 'false');
-    }
-  }, [isFirstVisit]);
-
-  if (isFirstVisit) {
-    return <LandingPage />;
-  } else {
-    return <Navigate to={PATH.HOME} replace />;
-  }
-}
 
 function Router() {
   return (
@@ -43,25 +26,19 @@ function Router() {
         </>
       )}
       <Routes>
-        {/* 퍼블릭 라우트 */}
-        <Route element={<MobileLayout />}>
-          {/* 루트 경로('/')에 RootRedirect 컴포넌트를 연결 */}
-          <Route path={PATH.LANDING} element={<RootRedirect />} />
-          {/* 홈은 인증/게스트 무관하게 접근 가능 */}
-          <Route path={PATH.HOME} element={<HomePage />} />
-        </Route>
-
-        {/* 게스트 전용 라우트 */}
+        {/* 게스트 전용 라우트: 랜딩/로그인/회원가입 */}
         <Route element={<RequireGuest />}>
           <Route element={<MobileLayout />}>
+            <Route path={PATH.LANDING} element={<LandingPage />} />
             <Route path={PATH.LOGIN} element={<LoginPage />} />
             <Route path={PATH.REGISTER} element={<RegisterPage />} />
           </Route>
         </Route>
 
-        {/* 인증 전용 라우트 */}
+        {/* 인증 전용 라우트: 홈/스페이스/플랜 */}
         <Route element={<RequireAuth />}>
           <Route element={<MobileLayout />}>
+            <Route path={PATH.HOME} element={<HomePage />} />
             <Route path={PATH.SPACE} element={<SpacePage />} />
           </Route>
 

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -4,9 +4,9 @@ import { Banner } from './components/Banner';
 import { NavLinks } from './components/NavLinks';
 import { TripSection, type Member } from './components/TripSection';
 import { useMemo } from 'react';
-import { mockPlans } from '../../mocks/data';
 import { useAuth } from '@/hooks/useAuth';
 import { useMemberQuery } from '@/pages/home/hooks/useMemberQuery';
+import { usePlansForHome } from '@/pages/home/hooks/usePlansQuery';
 
 const placeholderImages = {
   logo: '/logo.svg',
@@ -15,6 +15,7 @@ const placeholderImages = {
 function HomePage() {
   const { logout } = useAuth();
   const { data: me, isLoading } = useMemberQuery();
+  const { data: plans = [], isLoading: isPlansLoading } = usePlansForHome({ page: 0, size: 10 });
 
   const member: Member | null = useMemo(() => {
     if (!me) return null;
@@ -35,7 +36,7 @@ function HomePage() {
       </Header>
       <MainContent>
         <Banner />
-        <TripSection member={member} plans={mockPlans} isLoading={isLoading} />
+        <TripSection member={member} plans={plans} isLoading={isLoading || isPlansLoading} />
         <NavLinks />
       </MainContent>
       <Footer>

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -4,7 +4,8 @@ import { Banner } from './components/Banner';
 import { NavLinks } from './components/NavLinks';
 import { TripSection, type Member } from './components/TripSection';
 import { useState, useEffect } from 'react';
-import { mockMemberResponse, mockPlans } from '../../mocks/data'; 
+import { mockMemberResponse, mockPlans } from '../../mocks/data';
+import { useAuth } from '@/hooks/useAuth';
 
 const placeholderImages = {
   logo: '/logo.svg',
@@ -12,6 +13,7 @@ const placeholderImages = {
 
 function HomePage() {
   const [member, setMember] = useState<Member | null>(null);
+  const { logout } = useAuth();
 
   useEffect(() => {
     // 여기서 fetch나 axios를 사용해 API 호출
@@ -25,6 +27,7 @@ function HomePage() {
   return (
     <PageWrapper>
       <Header>
+        <LogoutButton onClick={logout}>로그아웃</LogoutButton>
         <Logo src={placeholderImages.logo} alt="Journey Planner Logo" />
       </Header>
       <MainContent>
@@ -53,6 +56,7 @@ const Header = styled.header`
   border-bottom: 1px solid ${colorSystem.tertiary_white._100};
   display: flex;
   justify-content: center;
+  position: relative;
 `;
 
 const Logo = styled.img`
@@ -72,6 +76,20 @@ const Footer = styled.footer`
   padding: 40px 0;
   display: flex;
   justify-content: center;
+`;
+
+const LogoutButton = styled.button`
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 8px 12px;
+  border-radius: 20px;
+  border: 1px solid ${colorSystem.tertiary_white._200};
+  background: ${colorSystem.tertiary_white._0};
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  color: ${colorSystem.tertiary_white._500};
 `;
 
 export default HomePage;

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -3,26 +3,29 @@ import { colorSystem } from '../../styles/colorSystem';
 import { Banner } from './components/Banner';
 import { NavLinks } from './components/NavLinks';
 import { TripSection, type Member } from './components/TripSection';
-import { useState, useEffect } from 'react';
-import { mockMemberResponse, mockPlans } from '../../mocks/data';
+import { useMemo } from 'react';
+import { mockPlans } from '../../mocks/data';
 import { useAuth } from '@/hooks/useAuth';
+import { useMemberQuery } from '@/pages/home/hooks/useMemberQuery';
 
 const placeholderImages = {
   logo: '/logo.svg',
 };
 
 function HomePage() {
-  const [member, setMember] = useState<Member | null>(null);
   const { logout } = useAuth();
+  const { data: me, isLoading } = useMemberQuery();
 
-  useEffect(() => {
-    // 여기서 fetch나 axios를 사용해 API 호출
-    setMember(mockMemberResponse.member);
-  }, []);
-
-  if (!member) {
-    return <div>로딩 중...</div>;
-  }
+  const member: Member | null = useMemo(() => {
+    if (!me) return null;
+    return {
+      id: 0,
+      email: me.email,
+      name: me.username,
+      contact: me.contact,
+      mbti: me.mbti,
+    };
+  }, [me]);
 
   return (
     <PageWrapper>
@@ -32,7 +35,7 @@ function HomePage() {
       </Header>
       <MainContent>
         <Banner />
-        <TripSection member={member} plans={mockPlans} />
+        <TripSection member={member} plans={mockPlans} isLoading={isLoading} />
         <NavLinks />
       </MainContent>
       <Footer>

--- a/src/pages/home/components/Banner.tsx
+++ b/src/pages/home/components/Banner.tsx
@@ -1,17 +1,19 @@
 import styled from 'styled-components';
 import { colorSystem } from '@styles/colorSystem';
 import { fontSystem } from '@styles/fontSystem';
-import { usePageRouting } from '@hooks/usePageRouting'; // 훅 가져오기
+import { useModal } from '@/hooks/useModal';
+import NewPlanWindow from '@/pages/space/components/planspace/NewPlanWindow';
 
 const placeholderImages = {
   newTripIcon: '🗺️',
 };
 
 export function Banner() {
-  const goto = usePageRouting(); // 훅 사용
+  const [newPlanWindow, openNewPlanModal] = useModal({ ModalWindow: NewPlanWindow });
 
   return (
     <BannerWrapper>
+      {newPlanWindow}
       <Title>
         <ColorSpan color={colorSystem.secondary_green._500}>J</ColorSpan>
         ourney
@@ -21,7 +23,7 @@ export function Banner() {
       <Subtitle>나의 계획을 친구들에게 공유해보세요</Subtitle>
 
       {/*추후 계획 생성 기능 추가시 고유 ID로 변경 필요*/}
-      <NewTripButton onClick={goto.plan('1234')}>
+      <NewTripButton onClick={openNewPlanModal}>
         <span>{placeholderImages.newTripIcon}</span> 새 여행 계획하기
       </NewTripButton>
     </BannerWrapper>

--- a/src/pages/home/components/NavLinks.tsx
+++ b/src/pages/home/components/NavLinks.tsx
@@ -4,7 +4,6 @@ import { fontSystem } from '../../../styles/fontSystem';
 import { usePageRouting } from '@/hooks/usePageRouting';
 
 const placeholderImages = {
-  paperAirplane: 'https://i.pinimg.com/1200x/e2/6c/d7/e26cd7ead75785115a7144fdef259cef.jpg',
   windowSeat: 'https://i.pinimg.com/1200x/fd/14/47/fd1447fb3c91db32c1bc0ccbc4055a23.jpg',
 };
 
@@ -13,9 +12,6 @@ export function NavLinks() {
 
   return (
     <NavLinksWrapper>
-      <NavLink image={placeholderImages.paperAirplane} onClick={goto.space}>
-        <span>모든 개인 스페이스 보기</span>
-      </NavLink>
       <NavLink image={placeholderImages.windowSeat} onClick={goto.space}>
         <span>Mypage</span>
       </NavLink>
@@ -25,13 +21,15 @@ export function NavLinks() {
 
 const NavLinksWrapper = styled.section`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 16px;
   width: 100%;
+  justify-items: center; /* 아이템을 수평 중앙 정렬 */
 `;
 
 const NavLink = styled.a<{ image: string }>`
   ${fontSystem.title.large};
+  width: clamp(240px, 90vw, 520px); /* 반응형 너비 축소 */
   height: 150px;
   border-radius: 8px;
   background-image: url(${({ image }) => image});
@@ -48,5 +46,7 @@ const NavLink = styled.a<{ image: string }>`
 
   @media (max-width: 768px) {
     ${fontSystem.title.small};
+    width: clamp(220px, 92vw, 460px);
+    height: 140px;
   }
 `;

--- a/src/pages/home/components/NavLinks.tsx
+++ b/src/pages/home/components/NavLinks.tsx
@@ -13,7 +13,7 @@ export function NavLinks() {
   return (
     <NavLinksWrapper>
       <NavLink image={placeholderImages.windowSeat} onClick={goto.space}>
-        <span>Mypage</span>
+        <span>MY SPACE</span>
       </NavLink>
     </NavLinksWrapper>
   );

--- a/src/pages/home/components/TripSection.tsx
+++ b/src/pages/home/components/TripSection.tsx
@@ -1,6 +1,11 @@
 import styled from 'styled-components';
 import { colorSystem } from '../../../styles/colorSystem';
 import { fontSystem } from '../../../styles/fontSystem';
+import Edit from '@/assets/icons/Edit';
+import Delete from '@/assets/icons/Delete';
+import { usePageRouting } from '@/hooks/usePageRouting';
+import { useModal } from '@/hooks/useModal';
+import DeletionConfirmWindow from '@/pages/space/components/planspace/DeletionConfirmWindow';
 
 const placeholderImages = {
   airplaneIcon: '✈️',
@@ -37,25 +42,47 @@ export function TripSection({ member, plans, isLoading }: TripSectionProps) {
       {isLoading || !member ? (
         <LoadingArea>로딩 중...</LoadingArea>
       ) : plans.length === 0 ? (
-        <EmptyArea>플랜이 없습니다</EmptyArea>
+        <EmptyArea>계획이 없습니다</EmptyArea>
       ) : (
         <TripList>
           {plans.map((plan) => (
-            <TripCard key={plan.id}>
-              <CardTitle>{plan.title}</CardTitle>
-              <CardBody>
-                <ul>
-                  <li>{plan.description}</li>
-                  <li>
-                    {plan.startDate} ~ {plan.endDate}
-                  </li>
-                </ul>
-              </CardBody>
-            </TripCard>
+            <HomePlanCard key={plan.id} plan={plan} />
           ))}
         </TripList>
       )}
     </>
+  );
+}
+
+function HomePlanCard({ plan }: { plan: Plan }) {
+  const goto = usePageRouting();
+  const [deletionConfirmModal, openDeletionConfirmWindow] = useModal({
+    ModalWindow: DeletionConfirmWindow,
+    // DeletionConfirmWindow는 space/types/plan 기반이지만 shape가 동일하므로 그대로 전달
+    modalProps: { plan: plan as unknown as any },
+  });
+
+  return (
+    <TripCard>
+      {deletionConfirmModal}
+      <CardControls>
+        <IconButton onClick={goto.plan(String(plan.id))} aria-label="edit">
+          <Edit />
+        </IconButton>
+        <IconButton onClick={openDeletionConfirmWindow} aria-label="delete">
+          <Delete />
+        </IconButton>
+      </CardControls>
+      <CardTitle>{plan.title}</CardTitle>
+      <CardBody>
+        <ul>
+          <DescriptionText>{plan.description}</DescriptionText>
+          <li>
+            {plan.startDate} ~ {plan.endDate}
+          </li>
+        </ul>
+      </CardBody>
+    </TripCard>
   );
 }
 
@@ -117,6 +144,7 @@ const TripCard = styled.div`
   flex: 0 0 auto;
   scroll-snap-align: start;
   background-color: ${colorSystem.tertiary_white._0};
+  position: relative;
 `;
 
 const CardTitle = styled.h3`
@@ -142,4 +170,28 @@ const CardBody = styled.div`
   li {
     margin-bottom: 8px;
   }
+`;
+
+const DescriptionText = styled.li`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2; /* 최대 2줄 표시 후 말줄임 */
+  -webkit-box-orient: vertical;
+  white-space: normal;
+`;
+
+const CardControls = styled.div`
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  gap: 8px;
+`;
+
+const IconButton = styled.button`
+  background: transparent;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
 `;

--- a/src/pages/home/components/TripSection.tsx
+++ b/src/pages/home/components/TripSection.tsx
@@ -36,6 +36,8 @@ export function TripSection({ member, plans, isLoading }: TripSectionProps) {
 
       {isLoading || !member ? (
         <LoadingArea>로딩 중...</LoadingArea>
+      ) : plans.length === 0 ? (
+        <EmptyArea>플랜이 없습니다</EmptyArea>
       ) : (
         <TripList>
           {plans.map((plan) => (
@@ -69,11 +71,31 @@ const TripList = styled.section`
   display: flex;
   gap: 16px;
   width: 100%;
-  justify-content: center;
-  margin-bottom: 32px;
+  max-width: 656px; /* 200*3 + 16*2 + padding(12*2) = 656 */
+  justify-content: flex-start;
+  margin: 0 auto 32px; /* 중앙 정렬 */
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x mandatory;
+  padding: 12px 12px 16px;
+  background-color: ${colorSystem.tertiary_white._50};
+  border-radius: 12px;
 `;
 
 const LoadingArea = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 200px;
+  color: ${colorSystem.tertiary_white._500};
+  border: 1px dashed ${colorSystem.tertiary_white._200};
+  border-radius: 8px;
+  margin-bottom: 32px;
+`;
+
+const EmptyArea = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -89,21 +111,24 @@ const TripCard = styled.div`
   border: 1px solid ${colorSystem.tertiary_white._100};
   border-radius: 8px;
   width: 200px;
-  height: 250px;
+  height: 200px; /* 세로 여유를 조금 줄임 */
   display: flex;
   flex-direction: column;
+  flex: 0 0 auto;
+  scroll-snap-align: start;
+  background-color: ${colorSystem.tertiary_white._0};
 `;
 
 const CardTitle = styled.h3`
   ${fontSystem.body.medium};
-  padding: 16px;
+  padding: 12px; /* 상하 패딩 축소 */
   border-bottom: 1px solid ${colorSystem.tertiary_white._100};
   margin: 0;
   font-weight: bold;
 `;
 
 const CardBody = styled.div`
-  padding: 16px;
+  padding: 12px; /* 상하 패딩 축소 */
   ul {
     list-style-type: none;
     padding-left: 0;

--- a/src/pages/home/components/TripSection.tsx
+++ b/src/pages/home/components/TripSection.tsx
@@ -22,32 +22,37 @@ export interface Member {
 }
 
 interface TripSectionProps {
-  member: Member
+  member: Member | null;
   plans: Plan[];
+  isLoading?: boolean;
 }
 
-export function TripSection({ member, plans }: TripSectionProps) {
+export function TripSection({ member, plans, isLoading }: TripSectionProps) {
   return (
     <>
       <WelcomeMessage>
-        {placeholderImages.airplaneIcon} {member.name}님 안녕하세요
+        {placeholderImages.airplaneIcon} {member ? `${member.name}님 안녕하세요` : '로딩 중...'}
       </WelcomeMessage>
 
-      <TripList>
-        {plans.map((plan) => (
-          <TripCard key={plan.id}>
-            <CardTitle>{plan.title}</CardTitle>
-            <CardBody>
-              <ul>
-                <li>{plan.description}</li>
-                <li>
-                  {plan.startDate} ~ {plan.endDate}
-                </li>
-              </ul>
-            </CardBody>
-          </TripCard>
-        ))}
-      </TripList>
+      {isLoading || !member ? (
+        <LoadingArea>로딩 중...</LoadingArea>
+      ) : (
+        <TripList>
+          {plans.map((plan) => (
+            <TripCard key={plan.id}>
+              <CardTitle>{plan.title}</CardTitle>
+              <CardBody>
+                <ul>
+                  <li>{plan.description}</li>
+                  <li>
+                    {plan.startDate} ~ {plan.endDate}
+                  </li>
+                </ul>
+              </CardBody>
+            </TripCard>
+          ))}
+        </TripList>
+      )}
     </>
   );
 }
@@ -65,6 +70,18 @@ const TripList = styled.section`
   gap: 16px;
   width: 100%;
   justify-content: center;
+  margin-bottom: 32px;
+`;
+
+const LoadingArea = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 200px;
+  color: ${colorSystem.tertiary_white._500};
+  border: 1px dashed ${colorSystem.tertiary_white._200};
+  border-radius: 8px;
   margin-bottom: 32px;
 `;
 

--- a/src/pages/home/hooks/useMemberQuery.ts
+++ b/src/pages/home/hooks/useMemberQuery.ts
@@ -1,0 +1,34 @@
+import { useQuery, type UseQueryOptions, type UseQueryResult } from '@tanstack/react-query';
+import axiosInstance from '@/api/axiosInstance';
+import { ENDPOINTS } from '@/api/endpoints';
+
+export type MemberMe = {
+  email: string;
+  contact: string;
+  username: string;
+  mbti: string;
+};
+
+const QUERY_KEY = ['memberInfo'] as const;
+
+async function fetchMemberMe(): Promise<MemberMe> {
+  const res = await axiosInstance.get(ENDPOINTS.members.me);
+  return res.data as MemberMe;
+}
+
+export function useMemberQuery<TData = MemberMe>(
+  options?: Omit<UseQueryOptions<MemberMe, unknown, TData, typeof QUERY_KEY>, 'queryKey' | 'queryFn'>
+): UseQueryResult<TData, unknown> {
+  return useQuery<MemberMe, unknown, TData, typeof QUERY_KEY>({
+    queryKey: QUERY_KEY,
+    queryFn: fetchMemberMe,
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+}
+
+export function useMemberUsername(): UseQueryResult<string, unknown> {
+  return useMemberQuery<string>({ select: (d) => d?.username ?? '' });
+}

--- a/src/pages/home/hooks/usePlansQuery.ts
+++ b/src/pages/home/hooks/usePlansQuery.ts
@@ -1,0 +1,93 @@
+import { useQuery, keepPreviousData, type UseQueryResult } from '@tanstack/react-query';
+import axiosInstance from '@/api/axiosInstance';
+import { ENDPOINTS } from '@/api/endpoints';
+import type { Plan as HomePlan } from '@/pages/home/components/TripSection';
+
+// 서버 응답 타입들
+type Traveler = {
+  id: number;
+  memberId: number;
+  name: string;
+  contact: string;
+  mbtiType: string; // e.g. 'INFJ'
+  status: string; // e.g. 'INVITED'
+  role: string; // e.g. 'DEFAULT'
+};
+
+type PlanItemResponse = {
+  id: number;
+  title: string;
+  description: string;
+  travelers: Traveler[];
+  startDate: string; // 'YYYY-MM-DD'
+  endDate: string; // 'YYYY-MM-DD'
+};
+
+type Page<T> = {
+  content: T[];
+  pageable: {
+    paged: boolean;
+    pageNumber: number;
+    pageSize: number;
+    offset: number;
+    sort: { sorted: boolean; empty: boolean; unsorted: boolean };
+    unpaged: boolean;
+  };
+  size: number;
+  number: number;
+  sort: { sorted: boolean; empty: boolean; unsorted: boolean };
+  numberOfElements: number;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+};
+
+export type PlansQueryParams = {
+  page?: number;
+  size?: number;
+  sort?: string[]; // e.g. ['createdAt,desc']
+  memberId?: number; // optional: 서버가 요구하면 전달
+};
+
+const QUERY_KEY_HOME = ['plans', 'home'] as const;
+
+async function fetchPlans(params: PlansQueryParams): Promise<Page<PlanItemResponse>> {
+  const { page = 0, size = 10, sort = ['createdAt,desc'], memberId } = params ?? {};
+  const query = {
+    page,
+    size,
+    sort,
+    ...(memberId !== undefined ? { memberId } : {}),
+  };
+  const res = await axiosInstance.get<Page<PlanItemResponse>>(ENDPOINTS.plans.base, { params: query });
+  return res.data;
+}
+
+// 홈 화면 카드에 맞춘 간단한 목록 전용 훅만 노출
+export function usePlansForHome(params: PlansQueryParams = {}): UseQueryResult<HomePlan[], unknown> {
+  const merged = {
+    page: params.page ?? 0,
+    size: params.size ?? 10,
+    sort: params.sort ?? ['createdAt,desc'],
+    memberId: params.memberId,
+  } satisfies PlansQueryParams;
+
+  return useQuery<Page<PlanItemResponse>, unknown, HomePlan[]>({
+    queryKey: [...QUERY_KEY_HOME, merged.page, merged.size, (merged.sort ?? []).join(','), merged.memberId ?? null],
+    queryFn: () => fetchPlans(merged),
+    select: (page) =>
+      page.content.map((p) => ({
+        id: p.id,
+        title: p.title,
+        description: p.description,
+        startDate: p.startDate,
+        endDate: p.endDate,
+      })),
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export const PLANS_HOME_QUERY_KEY = QUERY_KEY_HOME;

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -12,10 +12,9 @@ function LandingPage() {
   return (
     <LandingPageWrapper>
       <BackgroundImage src={background} alt="" />
-      <StartButton onClick={goto.login}>계획 만들기</StartButton>
+      <StartButton onClick={goto.login}>시작하기</StartButton>
       <LoginButton />
       <RegisterButton />
-      <HomeButton onClick={goto.home}>홈으로</HomeButton>
     </LandingPageWrapper>
   );
 }
@@ -32,24 +31,6 @@ const BackgroundImage = styled.img`
 const StartButton = styled.button`
   position: absolute;
   top: 13%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-
-  padding: clamp(12px, 2vw, 20px);
-  background-color: ${colorSystem.tertiary_white._0};
-  border: none;
-  border-radius: 16px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-
-  ${fontSystem.title.medium}
-  font-size: clamp(14px, 2vw, 20px);
-
-  cursor: pointer;
-`;
-
-const HomeButton = styled.button`
-  position: absolute;
-  bottom: 3.5%;
   left: 50%;
   transform: translate(-50%, -50%);
 

--- a/src/pages/space/SpacePage.tsx
+++ b/src/pages/space/SpacePage.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { useAuth } from '@/hooks/useAuth';
 import { STORAGE_KEYS } from '@/utils/storageKeys';
 import { useQueryClient } from '@tanstack/react-query';
+import { colorSystem } from '@/styles/colorSystem';
 
 function SpacePage() {
   const queryClient = useQueryClient();
@@ -27,12 +28,14 @@ function SpacePage() {
 
   return (
     <>
-      <TopBar>나의 스페이스</TopBar>
+      <TopBarContainer>
+        <TopBar>나의 스페이스</TopBar>
+        <LogoutButton onClick={logout}>로그아웃</LogoutButton>
+      </TopBarContainer>
       <SpacePageWrapper>
         <DevBar>
           <ExpireButton onClick={expireAccessToken}>액세스 토큰 만료 시뮬레이션</ExpireButton>
         </DevBar>
-        <LogoutButton onClick={logout}>임시 로그아웃</LogoutButton>
         <Profile />
         <PlanSpace />
       </SpacePageWrapper>
@@ -64,13 +67,23 @@ const ExpireButton = styled.button`
   color: #d9480f;
 `;
 
+const TopBarContainer = styled.div`
+  position: relative;
+`;
+
 const LogoutButton = styled.button`
-  align-self: flex-end;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
   padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid #ddd;
-  background: #fafafa;
+  border-radius: 20px;
+  border: 1px solid ${colorSystem.tertiary_white._200};
+  background: ${colorSystem.tertiary_white._0};
   cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  color: ${colorSystem.tertiary_white._500};
+  margin-right: 24px;
 `;
 
 export default SpacePage;

--- a/src/pages/space/components/planspace/PlanCard.tsx
+++ b/src/pages/space/components/planspace/PlanCard.tsx
@@ -6,6 +6,7 @@ import { usePageRouting } from '@/hooks/usePageRouting';
 import Delete from '@/assets/icons/Delete';
 import DeletionConfirmWindow from './DeletionConfirmWindow';
 import { useModal } from '@/hooks/useModal';
+import { colorSystem } from '@/styles/colorSystem';
 
 function PlanCard({ plan, highlight = false }: { plan: Plan; highlight?: boolean }) {
   const goto = usePageRouting();
@@ -98,8 +99,12 @@ const PlanCardWrapper = styled.div.withConfig({
   flex-direction: column;
   justify-content: center;
 
-  border-radius: 16px;
-  box-shadow: 0 2px 12px
-    ${({ highlight }) => (highlight ? `rgba(75, 206, 93, 0.3);` : `rgba(0, 0, 0, 0.08);`)};
+  border-radius: 40px;
+  /* 상단(하이라이트) 카드: 초록색 선, 나머지: 회색 선 */
+  border: 1px solid
+    ${({ highlight }) =>
+      highlight ? colorSystem.secondary_green._400 : colorSystem.tertiary_white._200};
+  /* 프로필 섹션과 동일한 그림자 적용 */
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
 `;
 export default PlanCard;

--- a/src/pages/space/components/planspace/PlanSpace.tsx
+++ b/src/pages/space/components/planspace/PlanSpace.tsx
@@ -7,6 +7,7 @@ import { useModal } from '@/hooks/useModal';
 import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
+import { colorSystem } from '@/styles/colorSystem';
 
 // API 응답 데이터 타입 정의
 interface PlansResponse {
@@ -36,20 +37,18 @@ function PlanSpace() {
   if (isLoading) return <PlanSpaceWrapper>계획 로딩 중...</PlanSpaceWrapper>;
   if (isError) return <PlanSpaceWrapper>계획을 불러오는데 실패했습니다.</PlanSpaceWrapper>;
 
-const latestPlanId = plans && plans.length > 0
-    ? Math.max(...plans.map(p => p.id))
-    : null;
+  const latestPlanId = plans && plans.length > 0 ? Math.max(...plans.map((p) => p.id)) : null;
 
   return (
     <PlanSpaceWrapper>
       {newPlanWindow}
+      <AddButton onClick={openNewPlanModal}>
+        <Add />새 여행 계획하기
+      </AddButton>
       {plans?.map((plan: Plan) => {
         // 현재 plan이 최신 plan이면 highlight를 true로 설정합니다.
         return <PlanCard key={plan.id} plan={plan} highlight={plan.id === latestPlanId} />;
       })}
-      <AddButton onClick={openNewPlanModal}>
-        <Add />새 여행 계획하기
-      </AddButton>
     </PlanSpaceWrapper>
   );
 }
@@ -59,8 +58,8 @@ const AddButton = styled.div`
   justify-content: center;
   align-items: center;
   padding: 20px;
-  border-radius: 16px;
-  box-shadow: 0 2px 12px rgba(255, 192, 77, 0.3);
+  border-radius: 30px;
+  border: 2px dashed ${colorSystem.tertiary_white._200};
   cursor: pointer;
 `;
 

--- a/src/pages/space/components/profile/InfoEditWindow.tsx
+++ b/src/pages/space/components/profile/InfoEditWindow.tsx
@@ -20,8 +20,9 @@ import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
 
 const updateMemberInfo = async (data: EditFormInputs) => {
-  const { phone, ...rest } = data;
-  const payload = { ...rest, contact: phone };
+  const { phone, name, ...rest } = data;
+  // 서버 스키마에 맞춰 name -> username, phone -> contact로 매핑
+  const payload = { ...rest, contact: phone, username: name };
   const response = await axiosInstance.patch(ENDPOINTS.members.me, payload);
   return response.data;
 };
@@ -91,7 +92,9 @@ function InfoEditWindow({ closeModal, member }: ModalPropType & { member: Member
         </FieldWrapper>
 
         <ControlBar>
-          <CancelButton type="button" onClick={closeModal}>취소</CancelButton>
+          <CancelButton type="button" onClick={closeModal}>
+            취소
+          </CancelButton>
           <CompleteButton type="submit" disabled={!isValid || mutation.isPending}>
             {mutation.isPending ? '수정 중...' : '수정'}
           </CompleteButton>

--- a/src/pages/space/components/profile/InfoEditWindow.tsx
+++ b/src/pages/space/components/profile/InfoEditWindow.tsx
@@ -20,9 +20,13 @@ import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
 
 const updateMemberInfo = async (data: EditFormInputs) => {
-  const { phone, name, ...rest } = data;
-  // 서버 스키마에 맞춰 name -> username, phone -> contact로 매핑
-  const payload = { ...rest, contact: phone, username: name };
+  // 서버 스펙: { email, contact, username, mbti }
+  const payload: { email: string; contact: string; username: string; mbti?: string } = {
+    email: data.email,
+    contact: data.phone,
+    username: data.name,
+  };
+  if (typeof data.mbti === 'string' && data.mbti.length > 0) payload.mbti = data.mbti;
   const response = await axiosInstance.patch(ENDPOINTS.members.me, payload);
   return response.data;
 };

--- a/src/pages/space/components/profile/Profile.tsx
+++ b/src/pages/space/components/profile/Profile.tsx
@@ -4,15 +4,24 @@ import { fontSystem } from '@/styles/fontSystem';
 import styled from 'styled-components';
 import InfoEditWindow from '@/pages/space/components/profile/InfoEditWindow';
 import type { MemberType } from '@/types/member';
+import type { MemberMe } from '@/pages/home/hooks/useMemberQuery';
 import PhotoEditWindow from '@/pages/space/components/profile/PhotoEditWindow';
 import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
 
 const fetchMemberInfo = async (): Promise<MemberType> => {
-  // axiosInstance를 사용하여 API 호출
-  const response = await axiosInstance.get<MemberType>(ENDPOINTS.members.me);
-  return response.data;
+  // 서버 스키마는 { email, contact, username, mbti }
+  const response = await axiosInstance.get<MemberMe>(ENDPOINTS.members.me);
+  const me = response.data;
+  // 화면/폼에서 사용하는 MemberType으로 매핑(name <- username)
+  return {
+    id: 0,
+    email: me.email,
+    name: me.username,
+    contact: me.contact,
+    mbti: me.mbti,
+  };
 };
 
 function Profile() {
@@ -57,7 +66,7 @@ function Profile() {
             </Entry>
             <Entry>
               <Section>이름</Section>
-              <div>{member.username}</div>
+              <div>{member.name}</div>
             </Entry>
             <Entry>
               <Section>연락처</Section>

--- a/src/pages/space/components/profile/Profile.tsx
+++ b/src/pages/space/components/profile/Profile.tsx
@@ -25,7 +25,11 @@ const fetchMemberInfo = async (): Promise<MemberType> => {
 };
 
 function Profile() {
-  const { data: member, isLoading, isError } = useQuery({
+  const {
+    data: member,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ['memberInfo'],
     queryFn: fetchMemberInfo,
   });
@@ -102,7 +106,7 @@ const ImagePlaceholder = styled.div`
 `;
 
 const EditPictureButton = styled.button`
-  color: ${colorSystem.primary_yellow._400};
+  color: ${colorSystem.tertiary_white._500};
   border: none;
   background-color: transparent;
 `;
@@ -158,7 +162,8 @@ const ProfileWrapper = styled.div`
   display: flex;
   flex-direction: column;
   border-radius: 40px;
-  box-shadow: 0 2px 12px rgba(255, 192, 77, 0.3);
+  border: 1px solid ${colorSystem.primary_yellow._300};
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
 `;
 
 export default Profile;


### PR DESCRIPTION
# 홈, 랜딩, 스페이스 페이지 기능구현, 수정 

## 설명

- 로그인 상태 시 홈, 비로그인 상태 시 랜딩 페이지만 접근 가능하도록 했습니다. (원래 있었던 isFirstVisit을 통한 랜딩/홈 리디렉트 로직은 삭제)
- 홈/랜딩 페이지를 인증 상태에 맞는 기능들을 구현했습니다.
- 랜딩 페이지의 시작하기 버튼을 누르면 로그인으로 리디렉트되고 로그인 이후 홈으로 리디렉트 됩니다. (로그인/회원가입 버튼도 유지)
- 홈 페이지의 새 계획 생성하기 버튼을 통해 계획을 바로 생성할 수 있습니다.
- 홈 페이지의 문구는 실제로 GET 요청을 통해 username을 가져와 출력합니다.
- 홈 페이지의 플랜 카드 란을 GET 요청을 통해 plan 목록을 가져와 출력합니다. 카드가 3개 이상일 때에는 가로 스크롤을 통해 확인 가능합니다.
- 홈 페이지의 각 플랜 카드들은 편집, 삭제 버튼을 통해 편집, 삭제 할 수 있습니다.
- 스페이스페이지의 UI를 다른 페이지와 통일감 있는 UI로 조정했습니다.
- 스페이스 페이지의 새 계획 추가하기 버튼을 프로필 하단에 고정했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logout functionality throughout the app.
  * Plan management actions (edit and delete) now available.
  * Enhanced loading and empty states for better user feedback.
  * Modal-based workflows for plan creation.

* **UI/UX Improvements**
  * Updated navigation layout and styling.
  * Refreshed button styling with improved borders and shadows.
  * Repositioned logout buttons for consistency.
  * Enhanced plan card visual hierarchy and styling.
  * Simplified routing structure for cleaner navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->