### PR TITLE
api 에러핸들링, suspense/errorboundary 적용

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { toastApiError } from '@/utils/apiError';
+
+type Props = {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+};
+
+type State = { hasError: boolean; error: unknown };
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: unknown) {
+    return { hasError: true, error } as State;
+  }
+
+  componentDidCatch(error: unknown) {
+    toastApiError(error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? null;
+    }
+    return this.props.children;
+  }
+}
+

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,52 @@
+import styled, { keyframes } from 'styled-components';
+
+type SpinnerProps = {
+  size?: number; // px
+  color?: string;
+  thickness?: number; // px
+  className?: string;
+};
+
+const spin = keyframes`
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+`;
+
+const Ring = styled.div<Required<Pick<SpinnerProps, 'size' | 'color' | 'thickness'>>>`
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
+  border-radius: 50%;
+  border: ${({ thickness }) => thickness}px solid rgba(0, 0, 0, 0.08);
+  border-top-color: ${({ color }) => color};
+  animation: ${spin} 0.8s linear infinite;
+  box-sizing: border-box;
+`;
+
+export function Spinner({ size = 16, color = '#999', thickness = 2, className }: SpinnerProps) {
+  return <Ring size={size} color={color} thickness={thickness} className={className} />;
+}
+
+// 섹션(블록) 로딩용: 가운데 정렬된 큰 스피너
+export function SectionSpinner({
+  size = 32,
+  color = '#999',
+  thickness = 3,
+  className,
+}: SpinnerProps) {
+  return (
+    <SectionWrapper className={className}>
+      <Spinner size={size} color={color} thickness={thickness} />
+    </SectionWrapper>
+  );
+}
+
+const SectionWrapper = styled.div`
+  width: 100%;
+  min-height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export default Spinner;
+

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -60,7 +60,7 @@ function HomeTripsBlock() {
   }, [me]);
 
   return (
-    <ErrorBoundary fallback={null}>
+    <ErrorBoundary fallback={<TripSectionFallback />}>
       <TripSection member={member} plans={plans} isLoading={false} />
     </ErrorBoundary>
   );

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -3,11 +3,12 @@ import { colorSystem } from '../../styles/colorSystem';
 import { Banner } from './components/Banner';
 import { NavLinks } from './components/NavLinks';
 import { TripSection, type Member } from './components/TripSection';
-import { useMemo, useEffect } from 'react';
+import { useMemo, Suspense } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useMemberQuery } from '@/pages/home/hooks/useMemberQuery';
 import { usePlansForHome } from '@/pages/home/hooks/usePlansQuery';
-import { toastApiError } from '@/utils/apiError';
+import Spinner, { SectionSpinner } from '@/components/Spinner';
+import ErrorBoundary from '@/components/ErrorBoundary';
 
 const placeholderImages = {
   logo: '/logo.svg',
@@ -15,17 +16,37 @@ const placeholderImages = {
 
 function HomePage() {
   const { logout } = useAuth();
-  const { data: me, isLoading, isError: isMeError, error: meError } = useMemberQuery();
-  const { data: plans = [], isLoading: isPlansLoading, isError: isPlansError, error: plansError } =
-    usePlansForHome({ page: 0, size: 10 });
 
-  useEffect(() => {
-    if (isMeError) toastApiError(meError);
-  }, [isMeError, meError]);
+  return (
+    <PageWrapper>
+      <Header>
+        <LogoutButton onClick={logout}>로그아웃</LogoutButton>
+        <Logo src={placeholderImages.logo} alt="Journey Planner Logo" />
+      </Header>
+      <HomeContent />
+      <Footer>
+        <Logo src={placeholderImages.logo} alt="Journey Planner Logo" />
+      </Footer>
+    </PageWrapper>
+  );
+}
 
-  useEffect(() => {
-    if (isPlansError) toastApiError(plansError);
-  }, [isPlansError, plansError]);
+function HomeContent() {
+  return (
+    <MainContent>
+      <Banner />
+      {/* TripSection 영역만 Suspense로 감싸 부분 로딩 처리 */}
+      <Suspense fallback={<TripSectionFallback />}> 
+        <HomeTripsBlock />
+      </Suspense>
+      <NavLinks />
+    </MainContent>
+  );
+}
+
+function HomeTripsBlock() {
+  const { data: me } = useMemberQuery();
+  const { data: plans = [] } = usePlansForHome({ page: 0, size: 10 });
 
   const member: Member | null = useMemo(() => {
     if (!me) return null;
@@ -39,20 +60,23 @@ function HomePage() {
   }, [me]);
 
   return (
-    <PageWrapper>
-      <Header>
-        <LogoutButton onClick={logout}>로그아웃</LogoutButton>
-        <Logo src={placeholderImages.logo} alt="Journey Planner Logo" />
-      </Header>
-      <MainContent>
-        <Banner />
-        <TripSection member={member} plans={plans} isLoading={isLoading || isPlansLoading} />
-        <NavLinks />
-      </MainContent>
-      <Footer>
-        <Logo src={placeholderImages.logo} alt="Journey Planner Logo" />
-      </Footer>
-    </PageWrapper>
+    <ErrorBoundary fallback={null}>
+      <TripSection member={member} plans={plans} isLoading={false} />
+    </ErrorBoundary>
+  );
+}
+
+function TripSectionFallback() {
+  return (
+    <div style={{ width: '100%' }}>
+      {/* 인사말 자리 */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+        <span style={{ marginRight: 8 }}>✈️</span>
+        <Spinner size={16} />
+      </div>
+      {/* 플랜 카드 자리 */}
+      <SectionSpinner />
+    </div>
   );
 }
 

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -3,10 +3,11 @@ import { colorSystem } from '../../styles/colorSystem';
 import { Banner } from './components/Banner';
 import { NavLinks } from './components/NavLinks';
 import { TripSection, type Member } from './components/TripSection';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useMemberQuery } from '@/pages/home/hooks/useMemberQuery';
 import { usePlansForHome } from '@/pages/home/hooks/usePlansQuery';
+import { toastApiError } from '@/utils/apiError';
 
 const placeholderImages = {
   logo: '/logo.svg',
@@ -14,8 +15,17 @@ const placeholderImages = {
 
 function HomePage() {
   const { logout } = useAuth();
-  const { data: me, isLoading } = useMemberQuery();
-  const { data: plans = [], isLoading: isPlansLoading } = usePlansForHome({ page: 0, size: 10 });
+  const { data: me, isLoading, isError: isMeError, error: meError } = useMemberQuery();
+  const { data: plans = [], isLoading: isPlansLoading, isError: isPlansError, error: plansError } =
+    usePlansForHome({ page: 0, size: 10 });
+
+  useEffect(() => {
+    if (isMeError) toastApiError(meError);
+  }, [isMeError, meError]);
+
+  useEffect(() => {
+    if (isPlansError) toastApiError(plansError);
+  }, [isPlansError, plansError]);
 
   const member: Member | null = useMemo(() => {
     if (!me) return null;

--- a/src/pages/home/hooks/useMemberQuery.ts
+++ b/src/pages/home/hooks/useMemberQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useSuspenseQuery, type UseSuspenseQueryResult } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
 
@@ -16,8 +16,8 @@ async function fetchMemberMe(): Promise<MemberMe> {
   return res.data as MemberMe;
 }
 
-export function useMemberQuery<TData = MemberMe>(): UseQueryResult<TData, unknown> {
-  return useQuery<MemberMe, unknown, TData, typeof QUERY_KEY>({
+export function useMemberQuery<TData = MemberMe>(): UseSuspenseQueryResult<TData, unknown> {
+  return useSuspenseQuery<MemberMe, unknown, TData, typeof QUERY_KEY>({
     queryKey: QUERY_KEY,
     queryFn: fetchMemberMe,
     // 홈 재진입마다 항상 최신 데이터 요청
@@ -28,9 +28,9 @@ export function useMemberQuery<TData = MemberMe>(): UseQueryResult<TData, unknow
   });
 }
 
-export function useMemberUsername(): UseQueryResult<string, unknown> {
+export function useMemberUsername(): UseSuspenseQueryResult<string, unknown> {
   // 별도 쿼리 선언으로 username만 선택 반환
-  return useQuery<MemberMe, unknown, string, typeof QUERY_KEY>({
+  return useSuspenseQuery<MemberMe, unknown, string, typeof QUERY_KEY>({
     queryKey: QUERY_KEY,
     queryFn: fetchMemberMe,
     select: (d) => d.username,

--- a/src/pages/home/hooks/useMemberQuery.ts
+++ b/src/pages/home/hooks/useMemberQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryOptions, type UseQueryResult } from '@tanstack/react-query';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
 
@@ -16,9 +16,7 @@ async function fetchMemberMe(): Promise<MemberMe> {
   return res.data as MemberMe;
 }
 
-export function useMemberQuery<TData = MemberMe>(
-  options?: Omit<UseQueryOptions<MemberMe, unknown, TData, typeof QUERY_KEY>, 'queryKey' | 'queryFn'>
-): UseQueryResult<TData, unknown> {
+export function useMemberQuery<TData = MemberMe>(): UseQueryResult<TData, unknown> {
   return useQuery<MemberMe, unknown, TData, typeof QUERY_KEY>({
     queryKey: QUERY_KEY,
     queryFn: fetchMemberMe,
@@ -27,10 +25,18 @@ export function useMemberQuery<TData = MemberMe>(
     gcTime: 5 * 60 * 1000,
     refetchOnMount: 'always',
     refetchOnWindowFocus: false,
-    ...options,
   });
 }
 
 export function useMemberUsername(): UseQueryResult<string, unknown> {
-  return useMemberQuery<string>({ select: (d) => d?.username ?? '' });
+  // 별도 쿼리 선언으로 username만 선택 반환
+  return useQuery<MemberMe, unknown, string, typeof QUERY_KEY>({
+    queryKey: QUERY_KEY,
+    queryFn: fetchMemberMe,
+    select: (d) => d.username,
+    staleTime: 0,
+    gcTime: 5 * 60 * 1000,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
+  });
 }

--- a/src/pages/home/hooks/usePlansQuery.ts
+++ b/src/pages/home/hooks/usePlansQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useSuspenseQuery, type UseSuspenseQueryResult } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
 import type { Plan as HomePlan } from '@/pages/home/components/TripSection';
@@ -66,7 +66,7 @@ async function fetchPlans(params: PlansQueryParams): Promise<Page<PlanItemRespon
 // 홈 화면 카드에 맞춘 간단한 목록 전용 훅만 노출
 export function usePlansForHome(
   params: PlansQueryParams = {}
-): UseQueryResult<HomePlan[], unknown> {
+): UseSuspenseQueryResult<HomePlan[], unknown> {
   const merged = {
     page: params.page ?? 0,
     size: params.size ?? 10,
@@ -74,7 +74,7 @@ export function usePlansForHome(
     memberId: params.memberId,
   } satisfies PlansQueryParams;
 
-  return useQuery<Page<PlanItemResponse>, unknown, HomePlan[]>({
+  return useSuspenseQuery<Page<PlanItemResponse>, unknown, HomePlan[]>({
     queryKey: [...QUERY_KEY_HOME, merged.page, merged.size, (merged.sort ?? []).join(','), merged.memberId ?? null],
     queryFn: () => fetchPlans(merged),
     select: (page) =>

--- a/src/pages/home/hooks/usePlansQuery.ts
+++ b/src/pages/home/hooks/usePlansQuery.ts
@@ -64,7 +64,9 @@ async function fetchPlans(params: PlansQueryParams): Promise<Page<PlanItemRespon
 }
 
 // 홈 화면 카드에 맞춘 간단한 목록 전용 훅만 노출
-export function usePlansForHome(params: PlansQueryParams = {}): UseQueryResult<HomePlan[], unknown> {
+export function usePlansForHome(
+  params: PlansQueryParams = {}
+): UseQueryResult<HomePlan[], unknown> {
   const merged = {
     page: params.page ?? 0,
     size: params.size ?? 10,

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -3,12 +3,13 @@ import logo from '../../../public/logo.svg';
 import { fontSystem } from '@/styles/fontSystem';
 import { colorSystem } from '@/styles/colorSystem';
 import { useLoginForm } from '@/pages/login/hooks/useLoginForm';
+import Spinner from '@/components/Spinner';
 import { FormInputField } from '@/components/FormInputField';
 import type { LoginFormInputs } from '@/pages/login/utils/loginValidation';
 import TopBar from '@/components/TopBar';
 
 function LoginPage() {
-  const { register, handleSubmit, errors, isValid, navigateToRegister } = useLoginForm();
+  const { register, handleSubmit, errors, isValid, navigateToRegister, isPending } = useLoginForm();
 
   return (
     <Container>
@@ -38,8 +39,8 @@ function LoginPage() {
               회원가입
             </SignupLink>
           </SignupGuide>
-          <LoginButton type="submit" disabled={!isValid}>
-            로그인
+          <LoginButton type="submit" disabled={!isValid || isPending}>
+            {isPending ? <Spinner size={16} color="#fff" /> : '로그인'}
           </LoginButton>
         </StyledForm>
       </Content>
@@ -90,6 +91,9 @@ const LoginButton = styled.button`
   ${fontSystem.body.large}
   cursor: pointer;
   transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   &:hover {
     background: ${colorSystem.secondary_green._500};
   }

--- a/src/pages/login/hooks/useLoginForm.ts
+++ b/src/pages/login/hooks/useLoginForm.ts
@@ -13,7 +13,7 @@ type LoginRedirectState = {
 
 export const useLoginForm = () => {
   const routing = usePageRouting();
-  const { mutateAsync } = useLoginMutation();
+  const { mutateAsync, isPending } = useLoginMutation();
   const location = useLocation();
   const navigate = useNavigate();
   const from = (location.state as LoginRedirectState | undefined)?.from?.pathname ?? PATH.HOME;
@@ -45,5 +45,6 @@ export const useLoginForm = () => {
     errors,
     isValid,
     navigateToRegister,
+    isPending,
   };
 };

--- a/src/pages/login/hooks/useLoginForm.ts
+++ b/src/pages/login/hooks/useLoginForm.ts
@@ -3,18 +3,9 @@ import { usePageRouting } from '@/hooks/usePageRouting';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema, type LoginFormInputs } from '@/pages/login/utils/loginValidation';
 import { useLoginMutation } from '@/pages/login/hooks/useLoginMutation';
-import { toast } from 'react-toastify';
-import axios from 'axios';
+import { toastApiError } from '@/utils/apiError';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { PATH } from '@/utils/path';
-
-function getServerMessage(data: unknown): string | undefined {
-  if (data && typeof data === 'object' && 'message' in data) {
-    const msg = (data as { message?: unknown }).message;
-    return typeof msg === 'string' ? msg : undefined;
-  }
-  return undefined;
-}
 
 type LoginRedirectState = {
   from?: { pathname?: string };
@@ -22,7 +13,7 @@ type LoginRedirectState = {
 
 export const useLoginForm = () => {
   const routing = usePageRouting();
-  const { mutate } = useLoginMutation();
+  const { mutateAsync } = useLoginMutation();
   const location = useLocation();
   const navigate = useNavigate();
   const from = (location.state as LoginRedirectState | undefined)?.from?.pathname ?? PATH.HOME;
@@ -35,39 +26,13 @@ export const useLoginForm = () => {
     mode: 'onChange',
   });
 
-  const onSubmit = (data: LoginFormInputs) => {
-    mutate(
-      { email: data.email, password: data.password },
-      {
-        onSuccess: () => {
-          // 원래 가려던 경로(from)로 이동, 없으면 HOME
-          navigate(from, { replace: true });
-        },
-        onError: (e) => {
-          const status = axios.isAxiosError(e) ? e.response?.status : undefined;
-          if (status === 400) {
-            toast.error('이메일/비밀번호를 확인해주세요.');
-            return;
-          }
-          if (status === 429) {
-            toast.error('요청이 많습니다. 잠시 후 다시 시도하세요.');
-            return;
-          }
-          if (status === 404) {
-            toast.error('존재하지 않는 계정입니다.');
-            return;
-          }
-          if (typeof status === 'number' && status >= 500) {
-            toast.error('서버 오류가 발생했습니다. 잠시 후 다시 시도하세요.');
-            return;
-          }
-          const fallback = axios.isAxiosError(e)
-            ? getServerMessage(e.response?.data) ?? e.message
-            : '요청을 처리할 수 없습니다.';
-          toast.error(fallback);
-        },
-      }
-    );
+  const onSubmit = async (data: LoginFormInputs) => {
+    try {
+      await mutateAsync({ email: data.email, password: data.password });
+      navigate(from, { replace: true });
+    } catch (e) {
+      toastApiError(e);
+    }
   };
 
   const navigateToRegister = () => {

--- a/src/pages/register/RegisterPage.tsx
+++ b/src/pages/register/RegisterPage.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { useRegisterForm } from '@/pages/register/hooks/useRegisterForm';
+import Spinner from '@/components/Spinner';
 import { FormInputField } from '@/components/FormInputField';
 import { mbtiTypes, type RegisterFormInputs } from '@/pages/register/utils/registerValidation';
 import { fontSystem } from '@/styles/fontSystem';
@@ -9,7 +10,7 @@ import { FormSelectField } from '@/components/FormSelectField';
 import TopBar from '@/components/TopBar';
 
 function RegisterPage() {
-  const { register, handleSubmit, errors, isValid } = useRegisterForm();
+  const { register, handleSubmit, errors, isValid, isPending } = useRegisterForm();
   const navigate = useNavigate();
 
   return (
@@ -63,8 +64,8 @@ function RegisterPage() {
             options={mbtiTypes}
             placeholder="MBTI를 선택하세요"
           />
-          <SubmitButton type="submit" disabled={!isValid}>
-            가입하기
+          <SubmitButton type="submit" disabled={!isValid || isPending}>
+            {isPending ? <Spinner size={16} color="#fff" /> : '가입하기'}
           </SubmitButton>
           <LoginGuide>
             이미 계정이 있으신가요?{' '}
@@ -118,6 +119,9 @@ const SubmitButton = styled.button`
   ${fontSystem.body.large}
   cursor: pointer;
   transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   &:hover:not(:disabled) {
     background: ${colorSystem.secondary_green._500};

--- a/src/pages/register/hooks/useRegisterForm.ts
+++ b/src/pages/register/hooks/useRegisterForm.ts
@@ -3,12 +3,11 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { registerSchema, type RegisterFormInputs } from '@/pages/register/utils/registerValidation';
 import { usePageRouting } from '@/hooks/usePageRouting';
 import { useRegisterMutation } from '@/pages/register/hooks/useRegisterMutation';
-import { toast } from 'react-toastify';
-import axios from 'axios';
+import { toastApiError } from '@/utils/apiError';
 
 export const useRegisterForm = () => {
   const routing = usePageRouting();
-  const { mutate } = useRegisterMutation();
+  const { mutateAsync } = useRegisterMutation();
 
   const {
     register,
@@ -19,49 +18,17 @@ export const useRegisterForm = () => {
     mode: 'onChange',
   });
 
-  function getServerMessage(data: unknown): string | undefined {
-    if (data && typeof data === 'object' && 'message' in data) {
-      const msg = (data as { message?: unknown }).message;
-      return typeof msg === 'string' ? msg : undefined;
+  const onSubmit = async (data: RegisterFormInputs) => {
+    try {
+      const res = await mutateAsync(data);
+      if (res?.accessToken && res?.refreshToken) {
+        routing.home();
+      } else {
+        routing.login();
+      }
+    } catch (e) {
+      toastApiError(e);
     }
-    return undefined;
-  }
-
-  const onSubmit = (data: RegisterFormInputs) => {
-    mutate(data, {
-      onSuccess: (res) => {
-        // 토큰이 있으면 useRegisterMutation에서 자동 로그인 처리됨
-        if (res.accessToken && res.refreshToken) {
-          routing.home();
-        } else {
-          toast.error('회원가입이 완료되었습니다. 로그인해 주세요.');
-          routing.login();
-        }
-      },
-      onError: (e) => {
-        const status = axios.isAxiosError(e) ? e.response?.status : undefined;
-        if (status === 400) {
-          toast.error('입력값을 확인해주세요.');
-          return;
-        }
-        if (status === 409) {
-          toast.error('이미 존재하는 계정입니다.');
-          return;
-        }
-        if (status === 429) {
-          toast.error('요청이 많습니다. 잠시 후 다시 시도하세요.');
-          return;
-        }
-        if (typeof status === 'number' && status >= 500) {
-          toast.error('서버 오류가 발생했습니다. 잠시 후 다시 시도하세요.');
-          return;
-        }
-        const fallback = axios.isAxiosError(e)
-          ? getServerMessage(e.response?.data) ?? e.message
-          : '요청을 처리할 수 없습니다.';
-        toast.error(fallback);
-      },
-    });
   };
 
   return {

--- a/src/pages/register/hooks/useRegisterForm.ts
+++ b/src/pages/register/hooks/useRegisterForm.ts
@@ -7,7 +7,7 @@ import { toastApiError } from '@/utils/apiError';
 
 export const useRegisterForm = () => {
   const routing = usePageRouting();
-  const { mutateAsync } = useRegisterMutation();
+  const { mutateAsync, isPending } = useRegisterMutation();
 
   const {
     register,
@@ -36,5 +36,6 @@ export const useRegisterForm = () => {
     handleSubmit: handleSubmit(onSubmit),
     errors,
     isValid,
+    isPending,
   };
 };

--- a/src/pages/space/SpacePage.tsx
+++ b/src/pages/space/SpacePage.tsx
@@ -4,6 +4,9 @@ import PlanSpace from '@/pages/space/components/planspace/PlanSpace';
 import styled from 'styled-components';
 import { useAuth } from '@/hooks/useAuth';
 import { colorSystem } from '@/styles/colorSystem';
+import { Suspense } from 'react';
+import { SectionSpinner } from '@/components/Spinner';
+import ErrorBoundary from '@/components/ErrorBoundary';
 
 function SpacePage() {
   const { logout } = useAuth();
@@ -15,8 +18,16 @@ function SpacePage() {
         <LogoutButton onClick={logout}>로그아웃</LogoutButton>
       </TopBarContainer>
       <SpacePageWrapper>
-        <Profile />
-        <PlanSpace />
+        <Suspense fallback={<ProfileFallback />}>
+          <ErrorBoundary fallback={<ProfileFallback />}>
+            <Profile />
+          </ErrorBoundary>
+        </Suspense>
+        <Suspense fallback={<SectionSpinner />}>
+          <ErrorBoundary fallback={<SectionSpinner />}>
+            <PlanSpace />
+          </ErrorBoundary>
+        </Suspense>
       </SpacePageWrapper>
     </>
   );
@@ -51,3 +62,24 @@ const LogoutButton = styled.button`
 `;
 
 export default SpacePage;
+
+function ProfileFallback() {
+  return (
+    <ProfileFallbackBox>
+      <SectionSpinner />
+    </ProfileFallbackBox>
+  );
+}
+
+const ProfileFallbackBox = styled.div`
+  width: 100%;
+  max-width: 100%;
+  padding: 28px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 40px;
+  border: 1px solid ${colorSystem.primary_yellow._300};
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  box-sizing: border-box;
+`;

--- a/src/pages/space/components/planspace/PlanSpace.tsx
+++ b/src/pages/space/components/planspace/PlanSpace.tsx
@@ -4,11 +4,9 @@ import PlanCard from './PlanCard';
 import Add from '@/assets/icons/Add';
 import NewPlanWindow from './NewPlanWindow';
 import { useModal } from '@/hooks/useModal';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
-import { useEffect } from 'react';
-import { toastApiError } from '@/utils/apiError';
 import { colorSystem } from '@/styles/colorSystem';
 
 // API 응답 데이터 타입 정의
@@ -23,26 +21,17 @@ const fetchPlans = async (): Promise<Plan[]> => {
 };
 
 function PlanSpace() {
-  const {
-    data: plans,
-    isLoading,
-    isError,
-    error,
-  } = useQuery({
+  const { data: plans } = useSuspenseQuery({
     queryKey: ['plans'],
     queryFn: fetchPlans,
+    staleTime: 0,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
-
-  useEffect(() => {
-    if (isError) toastApiError(error);
-  }, [isError, error]);
 
   const [newPlanWindow, openNewPlanModal] = useModal({
     ModalWindow: NewPlanWindow,
   });
-
-  if (isLoading) return <PlanSpaceWrapper>계획 로딩 중...</PlanSpaceWrapper>;
-  if (isError) return <PlanSpaceWrapper>계획을 불러오는데 실패했습니다.</PlanSpaceWrapper>;
 
   const latestPlanId = plans && plans.length > 0 ? Math.max(...plans.map((p) => p.id)) : null;
 

--- a/src/pages/space/components/planspace/PlanSpace.tsx
+++ b/src/pages/space/components/planspace/PlanSpace.tsx
@@ -7,6 +7,8 @@ import { useModal } from '@/hooks/useModal';
 import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
+import { useEffect } from 'react';
+import { toastApiError } from '@/utils/apiError';
 import { colorSystem } from '@/styles/colorSystem';
 
 // API 응답 데이터 타입 정의
@@ -25,10 +27,15 @@ function PlanSpace() {
     data: plans,
     isLoading,
     isError,
+    error,
   } = useQuery({
     queryKey: ['plans'],
     queryFn: fetchPlans,
   });
+
+  useEffect(() => {
+    if (isError) toastApiError(error);
+  }, [isError, error]);
 
   const [newPlanWindow, openNewPlanModal] = useModal({
     ModalWindow: NewPlanWindow,

--- a/src/pages/space/components/profile/Profile.tsx
+++ b/src/pages/space/components/profile/Profile.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import InfoEditWindow from '@/pages/space/components/profile/InfoEditWindow';
 import type { MemberType } from '@/types/member';
 import type { MemberMe } from '@/pages/home/hooks/useMemberQuery';
+import { useEffect } from 'react';
+import { toastApiError } from '@/utils/apiError';
 import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
@@ -28,10 +30,15 @@ function Profile() {
     data: member,
     isLoading,
     isError,
+    error,
   } = useQuery({
     queryKey: ['memberInfo'],
     queryFn: fetchMemberInfo,
   });
+
+  useEffect(() => {
+    if (isError) toastApiError(error);
+  }, [isError, error]);
 
   const [infoModalWindow, openInfoModal] = useModal(
     member

--- a/src/pages/space/components/profile/Profile.tsx
+++ b/src/pages/space/components/profile/Profile.tsx
@@ -5,9 +5,7 @@ import styled from 'styled-components';
 import InfoEditWindow from '@/pages/space/components/profile/InfoEditWindow';
 import type { MemberType } from '@/types/member';
 import type { MemberMe } from '@/pages/home/hooks/useMemberQuery';
-import { useEffect } from 'react';
-import { toastApiError } from '@/utils/apiError';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import axiosInstance from '@/api/axiosInstance';
 import { ENDPOINTS } from '@/api/endpoints';
 
@@ -26,19 +24,13 @@ const fetchMemberInfo = async (): Promise<MemberType> => {
 };
 
 function Profile() {
-  const {
-    data: member,
-    isLoading,
-    isError,
-    error,
-  } = useQuery({
+  const { data: member } = useSuspenseQuery({
     queryKey: ['memberInfo'],
     queryFn: fetchMemberInfo,
+    staleTime: 0,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
   });
-
-  useEffect(() => {
-    if (isError) toastApiError(error);
-  }, [isError, error]);
 
   const [infoModalWindow, openInfoModal] = useModal(
     member
@@ -51,9 +43,7 @@ function Profile() {
       : { ModalWindow: () => null }
   );
 
-  if (isLoading) return <ProfileWrapper>프로필 로딩 중...</ProfileWrapper>;
-  if (isError) return <ProfileWrapper>프로필을 불러오는데 실패했습니다.</ProfileWrapper>;
-  if (!member) return <ProfileWrapper>프로필 데이터가 없습니다.</ProfileWrapper>;
+  if (!member) return null;
 
   return (
     <>

--- a/src/utils/apiError.ts
+++ b/src/utils/apiError.ts
@@ -1,0 +1,23 @@
+import type { AxiosError } from 'axios';
+import { toast } from 'react-toastify';
+
+export function getServerMessage(error: unknown): string {
+  const fallback = '요청을 처리할 수 없습니다.';
+  if (!error || typeof error !== 'object') return fallback;
+  // AxiosError 형태 추론
+  const err = error as Partial<AxiosError> & { response?: { data?: any; statusText?: string } };
+  const data = err.response?.data as any;
+  const msg = typeof data?.message === 'string' ? data.message : undefined;
+  if (msg) return msg;
+  const statusText = err.response?.statusText;
+  if (typeof statusText === 'string' && statusText.length > 0) return statusText;
+  const generic = (error as any)?.message;
+  if (typeof generic === 'string' && generic.length > 0) return generic;
+  return fallback;
+}
+
+export function toastApiError(error: unknown) {
+  const msg = getServerMessage(error);
+  toast.error(msg);
+}
+


### PR DESCRIPTION
# api 에러핸들링, suspense/errorboundary 적용

## 설명

- 원래 프론트엔드에서 HTTP에러코드만을 이용해 분기했던 api에러핸들링 로직을 서버에서 내려주는 message를 그대로 이용하도록 수정했습니다.
- 각 페이지마다 다르던 api에러핸들링 로직을 일관화했습니다.
- 로딩중... 같은 로딩UI나 로딩UI가 없는 부분들을 로딩스피너 컴포넌트를 생성해 일관화했습니다.
- useQuery사용하던 부분 useSuspenseQuery로 바꾸어 suspense/errorboundary 적용했습니다.
- errorboundary는 토스트로 서버의 에러메시지를 출력하고, 해당 부분을 로딩스피너로 대체합니다.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error boundary components for improved error handling and recovery.
  * Introduced loading spinners for data fetching and form submission states.
  * Enhanced login and registration forms with loading indicators during submission.

* **Style**
  * Updated button layouts to center spinner and text content during loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->